### PR TITLE
feat: add InstancedMesh2 demo page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@rjsf/core": "^5.24.13",
         "@rjsf/utils": "^5.24.13",
         "@rjsf/validator-ajv8": "^5.24.13",
+        "@three.ez/instanced-mesh": "^0.3.7",
         "@types/three": "^0.180.0",
         "ai": "^5.0.44",
         "assert": "^2.1.0",
@@ -3096,6 +3097,18 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@three.ez/instanced-mesh": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@three.ez/instanced-mesh/-/instanced-mesh-0.3.7.tgz",
+      "integrity": "sha512-G+X47ICLWRga0pZV+t7Fr6wQ82MEfasH4LobnwE48MukpjMJ7+Mh2a94sgj/fzS6KKgFs+15RxsR9Kq5tLMPKg==",
+      "license": "MIT",
+      "dependencies": {
+        "bvh.js": "^0.0.13"
+      },
+      "peerDependencies": {
+        "three": ">=0.159.0"
+      }
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
@@ -4129,6 +4142,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
+    },
+    "node_modules/bvh.js": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/bvh.js/-/bvh.js-0.0.13.tgz",
+      "integrity": "sha512-7jVxKGyyATOwEoqFvghXoStJXkkmqf7JIXYEG44eMtMXQoeCwZL2n1z5/kZogFKvCaN7XweS2TKnqdyDrd0DJA==",
+      "license": "MIT"
     },
     "node_modules/cac": {
       "version": "6.7.14",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@rjsf/core": "^5.24.13",
     "@rjsf/utils": "^5.24.13",
     "@rjsf/validator-ajv8": "^5.24.13",
+    "@three.ez/instanced-mesh": "^0.3.7",
     "@types/three": "^0.180.0",
     "ai": "^5.0.44",
     "assert": "^2.1.0",

--- a/src/app/instanced-mesh/page.tsx
+++ b/src/app/instanced-mesh/page.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { Canvas, useFrame } from '@react-three/fiber'
+import { Suspense, useEffect, useMemo } from 'react'
+import * as THREE from 'three'
+import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js'
+import { InstancedMesh2 } from '@three.ez/instanced-mesh'
+import { useGLTF } from '@react-three/drei'
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js'
+
+function StaticTrees() {
+  const mesh = useMemo(() => {
+    const trunk = new THREE.CylinderGeometry(0.1, 0.1, 1)
+    const leaves = new THREE.ConeGeometry(0.5, 1, 8)
+    leaves.translate(0, 1, 0)
+    const geometry = mergeGeometries([trunk, leaves], true) as THREE.BufferGeometry
+    const materials = [
+      new THREE.MeshStandardMaterial({ color: '#8B4513' }),
+      new THREE.MeshStandardMaterial({ color: '#228B22' }),
+    ]
+    const inst = new InstancedMesh2(geometry, materials)
+    const count = 200
+    inst.addInstances(count, (obj) => {
+      obj.position.set((Math.random() - 0.5) * 20, 0, (Math.random() - 0.5) * 20)
+      obj.updateMatrix()
+    })
+    return inst
+  }, [])
+
+  useEffect(() => () => {
+    mesh.geometry.dispose()
+    if (Array.isArray(mesh.material)) mesh.material.forEach((m) => m.dispose())
+    else mesh.material.dispose()
+  }, [mesh])
+
+  return <primitive object={mesh} />
+}
+
+const CHARACTER_URL =
+  'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF-Binary/CesiumMan.glb'
+useGLTF.preload(CHARACTER_URL)
+
+function SkinnedCharacters() {
+  const gltf = useGLTF(CHARACTER_URL) as GLTF
+  const count = 10
+  const { mesh, mixer } = useMemo(() => {
+    const skinned = gltf.scene.getObjectByProperty('type', 'SkinnedMesh') as THREE.SkinnedMesh
+    const geometry = skinned.geometry
+    const material = skinned.material as THREE.Material
+    const inst = new InstancedMesh2(geometry, material)
+    inst.initSkeleton(skinned.skeleton)
+    inst.addInstances(count, (obj) => {
+      obj.position.set((Math.random() - 0.5) * 10, 0, (Math.random() - 0.5) * 10)
+      obj.updateMatrix()
+    })
+    gltf.scene.traverse((o) => {
+      o.visible = false
+    })
+    const mx = new THREE.AnimationMixer(gltf.scene)
+    gltf.animations.forEach((clip) => {
+      mx.clipAction(clip).play()
+    })
+    return { mesh: inst, mixer: mx }
+  }, [gltf])
+
+  useFrame((_, delta) => {
+    mixer.update(delta)
+    for (let i = 0; i < count; i++) mesh.setBonesAt(i)
+  })
+
+  useEffect(() => () => {
+    mesh.dispose()
+  }, [mesh])
+
+  return (
+    <>
+      <primitive object={gltf.scene} />
+      <primitive object={mesh} />
+    </>
+  )
+}
+
+export default function InstancedMeshPage() {
+  return (
+    <div className="min-h-screen bg-gray-900">
+      <div className="p-8">
+        <h1 className="text-4xl font-bold text-white mb-4">InstancedMesh2 Demo</h1>
+        <p className="text-gray-300 mb-8">
+          Demonstrates static trees and skinned character instances using InstancedMesh2.
+        </p>
+        <div className="w-full h-[600px] bg-black rounded-lg overflow-hidden">
+          <Canvas camera={{ position: [10, 10, 10], fov: 50 }}>
+            <Suspense fallback={null}>
+              <ambientLight intensity={0.5} />
+              <directionalLight position={[5, 10, 7.5]} intensity={1} />
+              <StaticTrees />
+              <SkinnedCharacters />
+            </Suspense>
+          </Canvas>
+        </div>
+        <div className="mt-6">
+          <a
+            href="/"
+            className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors"
+          >
+            ← Back to Home
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/instanced-mesh/page.tsx
+++ b/src/app/instanced-mesh/page.tsx
@@ -18,7 +18,10 @@ function StaticTrees() {
       new THREE.MeshStandardMaterial({ color: '#8B4513' }),
       new THREE.MeshStandardMaterial({ color: '#228B22' }),
     ]
-    const inst = new InstancedMesh2(geometry, materials)
+    const inst = new InstancedMesh2<THREE.BufferGeometry, THREE.Material[]>(
+      geometry,
+      materials,
+    )
     const count = 200
     inst.addInstances(count, (obj) => {
       obj.position.set((Math.random() - 0.5) * 20, 0, (Math.random() - 0.5) * 20)
@@ -29,8 +32,7 @@ function StaticTrees() {
 
   useEffect(() => () => {
     mesh.geometry.dispose()
-    if (Array.isArray(mesh.material)) mesh.material.forEach((m) => m.dispose())
-    else mesh.material.dispose()
+    mesh.material.forEach((m) => m.dispose())
   }, [mesh])
 
   return <primitive object={mesh} />
@@ -47,7 +49,10 @@ function SkinnedCharacters() {
     const skinned = gltf.scene.getObjectByProperty('type', 'SkinnedMesh') as THREE.SkinnedMesh
     const geometry = skinned.geometry
     const material = skinned.material as THREE.Material
-    const inst = new InstancedMesh2(geometry, material)
+    const inst = new InstancedMesh2<THREE.BufferGeometry, THREE.Material>(
+      geometry,
+      material,
+    )
     inst.initSkeleton(skinned.skeleton)
     inst.addInstances(count, (obj) => {
       obj.position.set((Math.random() - 0.5) * 10, 0, (Math.random() - 0.5) * 10)


### PR DESCRIPTION
## Summary
- install `@three.ez/instanced-mesh`
- add InstancedMesh2 demo combining static trees and skinned characters

## Testing
- `npm test` *(fails: Docker is required but not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68c74f028734832fa1252187222c3aac