### PR TITLE
feat: improve grass simulation

### DIFF
--- a/src/components/GrassDemo.tsx
+++ b/src/components/GrassDemo.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 import { Environment, OrbitControls, StatsGl } from "@react-three/drei";
-import { Canvas, useFrame } from "@react-three/fiber";
-import { useMemo, useRef } from "react";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import { useEffect, useMemo, useRef } from "react";
 import * as THREE from "three";
+import { ImprovedNoise } from "three/examples/jsm/math/ImprovedNoise.js";
 
 /**
  * Utility: Build a simple blade geometry
  */
 function makeBladeGeometry({
-  segments = 5,
+  segments = 7,
   width = 0.035,
   height = 0.6,
   tipTaper = 0.9,
@@ -96,12 +97,24 @@ function useInteractionTexture({ size = 512, decay = 0.94 } = {}) {
       }),
     [size],
   );
+  const prevCanvas = useMemo(
+    () =>
+      Object.assign(document.createElement("canvas"), {
+        width: size,
+        height: size,
+      }),
+    [size],
+  );
   const ctx = useMemo(
     () =>
       canvas.getContext("2d", {
         willReadFrequently: false,
       }) as CanvasRenderingContext2D,
     [canvas],
+  );
+  const prevCtx = useMemo(
+    () => prevCanvas.getContext("2d") as CanvasRenderingContext2D,
+    [prevCanvas],
   );
   const texture = useMemo(() => {
     const t = new THREE.CanvasTexture(canvas);
@@ -110,8 +123,21 @@ function useInteractionTexture({ size = 512, decay = 0.94 } = {}) {
     t.magFilter = THREE.LinearFilter;
     return t;
   }, [canvas]);
+  const prevTexture = useMemo(() => {
+    const t = new THREE.CanvasTexture(prevCanvas);
+    t.wrapS = t.wrapT = THREE.RepeatWrapping;
+    t.minFilter = THREE.LinearFilter;
+    t.magFilter = THREE.LinearFilter;
+    return t;
+  }, [prevCanvas]);
 
   const fade = () => {
+    prevCtx.save();
+    prevCtx.globalCompositeOperation = "copy";
+    prevCtx.drawImage(canvas, 0, 0);
+    prevCtx.restore();
+    prevTexture.needsUpdate = true;
+
     ctx.save();
     ctx.globalCompositeOperation = "source-over";
     ctx.fillStyle = `rgba(0,0,0,${1 - decay})`;
@@ -143,7 +169,33 @@ function useInteractionTexture({ size = 512, decay = 0.94 } = {}) {
       texture.needsUpdate = true;
     };
 
-  return { texture, fade, makeStamper, size };
+  return { texture, prevTexture, fade, makeStamper, size };
+}
+
+function createHeightMapTexture(size = 1024) {
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext("2d")!;
+  const img = ctx.createImageData(size, size);
+  const data = img.data;
+  const perlin = new ImprovedNoise();
+  const z = Math.random() * 100;
+  let ptr = 0;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const v = (perlin.noise(x / 64, y / 64, z) + 1) * 0.5;
+      const col = v * 255;
+      data[ptr++] = col;
+      data[ptr++] = col;
+      data[ptr++] = col;
+      data[ptr++] = 255;
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+  tex.needsUpdate = true;
+  return tex;
 }
 
 const VERT = /* glsl */ `
@@ -153,6 +205,7 @@ attribute float aScale;
 attribute float aRotation;
 attribute float aCurv;
 attribute float aRand;
+attribute vec2 aTilt;
 uniform float uTime;
 uniform vec2 uWindDir;
 uniform float uWindAmp;
@@ -164,9 +217,10 @@ uniform sampler2D uHeightMap;
 uniform float uUseHeightMap;
 uniform float uHeightScale;
 uniform sampler2D uInteractTex;
+uniform sampler2D uInteractPrevTex;
 uniform float uUseInteract;
 uniform vec2 uInteractInvSize;
-uniform float uFlattenStrength;
+uniform float uBendStrength;
 varying vec3 vWorldPos;
 varying float vHeight01;
 vec3 mod289(vec3 x){ return x - floor(x * (1.0 / 289.0)) * 289.0; }
@@ -202,6 +256,7 @@ void main() {
   float gust = snoise(windU + aRand * 37.0);
   float sway = uWindAmp * mix(0.5, 1.0, aRand) * gust;
   vec2 dir = normalize(uWindDir + vec2(snoise((aOffset.xz + 2.7) * 0.05)));
+  p.xz += aTilt * p.y;
   vec2 worldXZ = aOffset.xz + rot2(aRotation) * p.xz;
   vec2 uvWorld = (worldXZ - uBoundsMin) / uBoundsSize;
   float interact = 0.0;
@@ -212,15 +267,21 @@ void main() {
     float cxm = texture2D(uInteractTex, uvWorld - vec2(uInteractInvSize.x, 0.0)).r;
     float cyp = texture2D(uInteractTex, uvWorld + vec2(0.0, uInteractInvSize.y)).r;
     float cym = texture2D(uInteractTex, uvWorld - vec2(0.0, uInteractInvSize.y)).r;
-    vec2 grad = vec2(cxp - cxm, cyp - cym);
-    bendFromInteract = (length(grad) > 1e-5) ? normalize(grad) : vec2(0.0);
+    float pxp = texture2D(uInteractPrevTex, uvWorld + vec2(uInteractInvSize.x, 0.0)).r;
+    float pxm = texture2D(uInteractPrevTex, uvWorld - vec2(uInteractInvSize.x, 0.0)).r;
+    float pyp = texture2D(uInteractPrevTex, uvWorld + vec2(0.0, uInteractInvSize.y)).r;
+    float pym = texture2D(uInteractPrevTex, uvWorld - vec2(0.0, uInteractInvSize.y)).r;
+    vec2 gradCurr = vec2(cxp - cxm, cyp - cym);
+    vec2 gradPrev = vec2(pxp - pxm, pyp - pym);
+    vec2 motion = gradCurr - gradPrev;
+    bendFromInteract = (length(motion) > 1e-5) ? -normalize(motion) : vec2(0.0);
     interact = c;
   }
   float bendAmt = (aCurv * 0.35 + sway * 0.25) * (h01 * h01);
-  vec2 bendDir = normalize(dir + bendFromInteract * 1.5);
+  bendAmt += interact * uBendStrength * h01;
+  vec2 bendDir = normalize(dir + bendFromInteract);
   p.xz += bendDir * bendAmt * uBladeBase;
-  float flatten = uFlattenStrength * interact * h01;
-  p.y *= aScale * (1.0 - clamp(flatten, 0.0, 0.95));
+  p.y *= aScale;
   p.xz = rot2(aRotation) * p.xz;
   float baseY = 0.0;
   if (uUseHeightMap > 0.5) {
@@ -271,7 +332,7 @@ interface GrassFieldProps {
   heightScale?: number;
   interaction?: boolean;
   interactionTexture?: ReturnType<typeof useInteractionTexture>;
-  flattenStrength?: number;
+  bendStrength?: number;
   colorA?: string;
   colorB?: string;
 }
@@ -290,7 +351,7 @@ function GrassField({
   heightScale = 2.5,
   interaction = true,
   interactionTexture,
-  flattenStrength = 0.9,
+  bendStrength = 0.9,
   colorA = "#446c3a",
   colorB = "#8bcf4a",
 }: GrassFieldProps) {
@@ -322,17 +383,23 @@ function GrassField({
     const yaws = new Float32Array(count);
     const curvs = new Float32Array(count);
     const rands = new Float32Array(count);
+    const tilts = new Float32Array(count * 2);
     for (let i = 0; i < count; i++) {
       scales[i] = 0.75 + Math.random() * 0.7;
       yaws[i] = Math.random() * Math.PI * 2;
       curvs[i] = 0.3 + Math.random() * 0.7;
       rands[i] = Math.random();
+      const tiltAngle = Math.random() * Math.PI * 2;
+      const tiltAmt = Math.random() * 0.3;
+      tilts[i * 2 + 0] = Math.cos(tiltAngle) * tiltAmt;
+      tilts[i * 2 + 1] = Math.sin(tiltAngle) * tiltAmt;
     }
     g.setAttribute("aOffset", new THREE.InstancedBufferAttribute(offsets, 3));
     g.setAttribute("aScale", new THREE.InstancedBufferAttribute(scales, 1));
     g.setAttribute("aRotation", new THREE.InstancedBufferAttribute(yaws, 1));
     g.setAttribute("aCurv", new THREE.InstancedBufferAttribute(curvs, 1));
     g.setAttribute("aRand", new THREE.InstancedBufferAttribute(rands, 1));
+    g.setAttribute("aTilt", new THREE.InstancedBufferAttribute(tilts, 2));
     g.boundingBox = new THREE.Box3(
       new THREE.Vector3(boundsMin.x, center[1], boundsMin.y),
       new THREE.Vector3(
@@ -379,6 +446,12 @@ function GrassField({
                 ? interactionTexture.texture
                 : null,
           },
+          uInteractPrevTex: {
+            value:
+              interaction && interactionTexture
+                ? interactionTexture.prevTexture
+                : null,
+          },
           uUseInteract: { value: interaction && interactionTexture ? 1 : 0 },
           uInteractInvSize: {
             value: new THREE.Vector2(
@@ -390,7 +463,7 @@ function GrassField({
                 : 1,
             ),
           },
-          uFlattenStrength: { value: flattenStrength },
+          uBendStrength: { value: bendStrength },
           uColorA: { value: new THREE.Color(colorA) },
           uColorB: { value: new THREE.Color(colorB) },
           uSunDir: { value: new THREE.Vector3(0.5, 1.0, 0.2).normalize() },
@@ -410,7 +483,7 @@ function GrassField({
       heightScale,
       interaction,
       interactionTexture,
-      flattenStrength,
+      bendStrength,
       colorA,
       colorB,
     ],
@@ -455,33 +528,75 @@ function RollingBall({
   );
 }
 
+interface CursorBallProps {
+  stamper: ReturnType<ReturnType<typeof useInteractionTexture>["makeStamper"]>;
+  boundsMin: THREE.Vector2;
+  boundsSize: THREE.Vector2;
+  radius?: number;
+}
+
+function CursorBall({ stamper, boundsMin, boundsSize, radius = 0.6 }: CursorBallProps) {
+  const ref = useRef<THREE.Mesh>(null);
+  const { camera } = useThree();
+  const mouse = useRef(new THREE.Vector2());
+  useEffect(() => {
+    const handle = (e: PointerEvent) => {
+      mouse.current.x = (e.clientX / window.innerWidth) * 2 - 1;
+      mouse.current.y = -(e.clientY / window.innerHeight) * 2 + 1;
+    };
+    window.addEventListener("pointermove", handle);
+    return () => window.removeEventListener("pointermove", handle);
+  }, []);
+  const plane = useMemo(() => new THREE.Plane(new THREE.Vector3(0, 1, 0), 0), []);
+  const ray = useMemo(() => new THREE.Raycaster(), []);
+  const pos = useMemo(() => new THREE.Vector3(), []);
+  useFrame(() => {
+    ray.setFromCamera(mouse.current, camera);
+    ray.ray.intersectPlane(plane, pos);
+    const x = THREE.MathUtils.clamp(pos.x, boundsMin.x, boundsMin.x + boundsSize.x);
+    const z = THREE.MathUtils.clamp(pos.z, boundsMin.y, boundsMin.y + boundsSize.y);
+    if (ref.current) ref.current.position.set(x, radius, z);
+    if (stamper) stamper(x, z, radius * 2.2, 1.0);
+  });
+  return (
+    <mesh ref={ref} castShadow receiveShadow>
+      <sphereGeometry args={[radius, 32, 32]} />
+      <meshStandardMaterial color="#dd3333" metalness={0.2} roughness={0.6} />
+    </mesh>
+  );
+}
+
 export function GrassDemo({
-  fieldSize = [28, 28],
-  bladeCount = 130_000,
-  useHeightMap = false,
-  heightScale = 2.5,
+  fieldSize = [200, 200],
+  bladeCount = 800_000,
+  useHeightMap = true,
+  heightScale = 3.0,
 }) {
   const [W, D] = fieldSize;
   const boundsMin = new THREE.Vector2(-W / 2, -D / 2);
   const boundsSize = new THREE.Vector2(W, D);
-  const heightMap = null;
+  const heightMap = useMemo(() => createHeightMapTexture(1024), []);
   const interact = useInteractionTexture({ size: 512, decay: 0.97 });
   const stamper = interact.makeStamper(
     new THREE.Vector2(boundsMin.x, boundsMin.y),
     new THREE.Vector2(boundsSize.x, boundsSize.y),
   );
   return (
-    <Canvas shadows camera={{ position: [10, 7, 10], fov: 45 }}>
+    <Canvas shadows camera={{ position: [30, 20, 30], fov: 45 }}>
       <color attach="background" args={["#9fd6ff"]} />
       <hemisphereLight intensity={0.5} groundColor="#7aa07a" />
-      <directionalLight position={[10, 15, 10]} intensity={1.2} castShadow />
+      <directionalLight position={[20, 25, 20]} intensity={1.2} castShadow />
       <mesh
         rotation={[-Math.PI / 2, 0, 0]}
         receiveShadow
-        position={[0, -0.001, 0]}
+        position={[0, -0.01, 0]}
       >
-        <planeGeometry args={[W, D, 1, 1]} />
-        <meshStandardMaterial color="#7cac65" />
+        <planeGeometry args={[W, D, 256, 256]} />
+        <meshStandardMaterial
+          color="#7cac65"
+          displacementMap={useHeightMap ? heightMap : null}
+          displacementScale={heightScale}
+        />
       </mesh>
       <GrassField
         size={[W, D]}
@@ -494,7 +609,7 @@ export function GrassDemo({
         heightScale={heightScale}
         interaction
         interactionTexture={interact}
-        flattenStrength={0.9}
+        bendStrength={0.9}
       />
       <RollingBall
         stamper={stamper}
@@ -502,6 +617,12 @@ export function GrassDemo({
         boundsSize={boundsSize}
         radius={0.65}
         speed={1.0}
+      />
+      <CursorBall
+        stamper={stamper}
+        boundsMin={boundsMin}
+        boundsSize={boundsSize}
+        radius={0.65}
       />
       <Environment preset="sunset" />
       <OrbitControls makeDefault />


### PR DESCRIPTION
## Summary
- enlarge grass field and render hills using a generated height map
- add tilt and motion-based bending for more natural grass
- introduce an interactive cursor-driven ball for grass interactions

## Testing
- `npm test` (fails: Docker is required but not found)
- `npm run lint` (fails: biome not found)


------
https://chatgpt.com/codex/tasks/task_e_68c7bf0ea6d8832f93d7778226d303ad