### PR TITLE
Add assembly editor with blueprint catalog demos

### DIFF
--- a/src/app/assembly-editor/page.tsx
+++ b/src/app/assembly-editor/page.tsx
@@ -1,0 +1,514 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import type { ChangeEvent } from 'react'
+import { BlueprintCanvas } from '../../components/assembly/BlueprintCanvas'
+import type { BlueprintRuntimeApi } from '../../components/assembly/BlueprintScene'
+import {
+  assemblyCatalog,
+  blueprintExamples,
+  getBlueprintPreset,
+  listBlueprintOptions,
+} from '../../lib/assemblyContent'
+import type { Blueprint, JointInstance, PartInstance } from '../../types/assembly'
+import { eulerDegToQuat, quatToEulerDeg } from '../../lib/assemblyMath'
+
+const cloneBlueprint = (blueprint: Blueprint) => JSON.parse(JSON.stringify(blueprint)) as Blueprint
+
+const formatNumber = (value: number, precision = 3) => Number.parseFloat(value.toFixed(precision))
+
+type Axis = 0 | 1 | 2
+
+type EulerTriple = [number, number, number]
+
+const axisLabels: Record<Axis, string> = { 0: 'X', 1: 'Y', 2: 'Z' }
+
+const PartTransformEditor = ({
+  part,
+  onUpdatePosition,
+  onUpdateRotation,
+  onReset,
+  onImpulse,
+}: {
+  part: PartInstance
+  onUpdatePosition: (axis: Axis, value: number) => void
+  onUpdateRotation: (euler: EulerTriple) => void
+  onReset: () => void
+  onImpulse: (impulse: [number, number, number]) => void
+}) => {
+  const euler = useMemo(() => quatToEulerDeg(part.transform.rotationQuat), [part.transform.rotationQuat])
+
+  const handlePositionChange = (axis: Axis, event: ChangeEvent<HTMLInputElement>) => {
+    const value = Number.parseFloat(event.target.value)
+    if (Number.isNaN(value)) return
+    onUpdatePosition(axis, value)
+  }
+
+  const handleRotationChange = (axis: Axis, event: ChangeEvent<HTMLInputElement>) => {
+    const value = Number.parseFloat(event.target.value)
+    if (Number.isNaN(value)) return
+    const next: EulerTriple = [...euler] as EulerTriple
+    next[axis] = value
+    onUpdateRotation(next)
+  }
+
+  const impulseOptions: Record<string, [number, number, number]> = {
+    'Push Forward': [0, 0, -5],
+    'Lift Up': [0, 5, 0],
+    'Nudge Right': [3, 0, 0],
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-neutral-400">Position (m)</h3>
+        <div className="mt-2 grid grid-cols-3 gap-3">
+          {[0, 1, 2].map((axis) => (
+            <label key={axis} className="flex flex-col gap-1 text-xs">
+              <span className="font-medium">{axisLabels[axis as Axis]}</span>
+              <input
+                type="number"
+                step={0.1}
+                value={formatNumber(part.transform.position[axis as Axis])}
+                onChange={(event) => handlePositionChange(axis as Axis, event)}
+                className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-sm"
+              />
+            </label>
+          ))}
+        </div>
+      </div>
+      <div>
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-neutral-400">Rotation (°)</h3>
+        <div className="mt-2 grid grid-cols-3 gap-3">
+          {[0, 1, 2].map((axis) => (
+            <label key={axis} className="flex flex-col gap-1 text-xs">
+              <span className="font-medium">{axisLabels[axis as Axis]}</span>
+              <input
+                type="number"
+                step={1}
+                value={formatNumber(euler[axis as Axis])}
+                onChange={(event) => handleRotationChange(axis as Axis, event)}
+                className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-sm"
+              />
+            </label>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {Object.entries(impulseOptions).map(([label, vector]) => (
+          <button
+            key={label}
+            type="button"
+            onClick={() => onImpulse(vector)}
+            className="rounded border border-neutral-700 px-2 py-1 text-xs hover:border-amber-400 hover:text-amber-300"
+          >
+            {label}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={onReset}
+          className="rounded border border-red-700 px-2 py-1 text-xs text-red-300 hover:bg-red-900/30"
+        >
+          Reset Transform
+        </button>
+      </div>
+      <div className="rounded border border-neutral-800 bg-neutral-950/80 p-3 text-xs text-neutral-400">
+        <p>Tip: hold <strong>Alt</strong> while dragging number inputs to nudge values precisely.</p>
+      </div>
+    </div>
+  )
+}
+
+const JointInspector = ({
+  joint,
+  templateName,
+  onSetVelocity,
+  onNudge,
+}: {
+  joint: JointInstance
+  templateName: string
+  onSetVelocity: (velocity: number) => void
+  onNudge: (velocity: number) => void
+}) => {
+  const currentTarget = joint.driveOverride?.target ?? 0
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-neutral-400">Joint Info</h3>
+        <dl className="mt-2 grid grid-cols-2 gap-2 text-xs text-neutral-300">
+          <dt className="font-semibold text-neutral-400">Template</dt>
+          <dd>{templateName}</dd>
+          <dt className="font-semibold text-neutral-400">Type</dt>
+          <dd>{joint.template}</dd>
+          {joint.articulationGroup ? (
+            <>
+              <dt className="font-semibold text-neutral-400">Articulation</dt>
+              <dd>{joint.articulationGroup}</dd>
+            </>
+          ) : null}
+        </dl>
+      </div>
+      <div>
+        <label className="flex flex-col gap-2 text-xs text-neutral-200">
+          <span className="font-semibold uppercase tracking-wide text-neutral-400">
+            Motor Target Velocity (rad/s)
+          </span>
+          <input
+            type="range"
+            min={-15}
+            max={15}
+            step={0.1}
+            value={currentTarget}
+            onChange={(event) => onSetVelocity(Number.parseFloat(event.target.value))}
+          />
+          <input
+            type="number"
+            className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-sm"
+            value={formatNumber(currentTarget)}
+            step={0.1}
+            onChange={(event) => onSetVelocity(Number.parseFloat(event.target.value))}
+          />
+        </label>
+      </div>
+      <div className="flex gap-2 text-xs">
+        <button
+          type="button"
+          onClick={() => onNudge(4)}
+          className="rounded border border-emerald-600 px-3 py-1 text-emerald-200 hover:bg-emerald-900/40"
+        >
+          Nudge +
+        </button>
+        <button
+          type="button"
+          onClick={() => onNudge(-4)}
+          className="rounded border border-blue-700 px-3 py-1 text-blue-200 hover:bg-blue-900/40"
+        >
+          Nudge -
+        </button>
+        <button
+          type="button"
+          onClick={() => onSetVelocity(0)}
+          className="rounded border border-neutral-600 px-3 py-1 text-neutral-200 hover:bg-neutral-800/50"
+        >
+          Stop
+        </button>
+      </div>
+      <div className="rounded border border-neutral-800 bg-neutral-950/80 p-3 text-xs text-neutral-400">
+        <p>
+          Use <strong>Nudge</strong> to kick the articulation open/closed. Set target velocity for continuous motion
+          (car wheels) or zero it out to hold position.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+const BlueprintJsonPreview = ({ blueprint }: { blueprint: Blueprint }) => {
+  const json = useMemo(() => JSON.stringify(blueprint, null, 2), [blueprint])
+  return (
+    <pre className="max-h-64 overflow-auto rounded border border-neutral-800 bg-neutral-950 p-3 text-xs text-neutral-300">
+      {json}
+    </pre>
+  )
+}
+
+export default function AssemblyEditorPage() {
+  const [selectedExample, setSelectedExample] = useState('example-house')
+  const [blueprint, setBlueprint] = useState<Blueprint>(() => getBlueprintPreset('example-house'))
+  const [selectedPartId, setSelectedPartId] = useState<string | null>('pi_door')
+  const [selectedJointId, setSelectedJointId] = useState<string | null>('joint_door')
+  const [showSockets, setShowSockets] = useState(true)
+  const [showJointDebug, setShowJointDebug] = useState(true)
+  const [manualWheelVelocity, setManualWheelVelocity] = useState(0)
+  const [runtimeApi, setRuntimeApi] = useState<BlueprintRuntimeApi | null>(null)
+
+  const exampleOptions = useMemo(() => listBlueprintOptions(), [])
+
+  const handleExampleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const exampleId = event.target.value
+    setSelectedExample(exampleId)
+    const fresh = getBlueprintPreset(exampleId)
+    setBlueprint(fresh)
+    setSelectedPartId(fresh.root.parts[0]?.id ?? null)
+    setSelectedJointId(fresh.root.joints[0]?.id ?? null)
+    setManualWheelVelocity(0)
+    runtimeApi?.setManualWheelVelocity(0)
+  }
+
+  const handleResetExample = () => {
+    const fresh = getBlueprintPreset(selectedExample)
+    setBlueprint(fresh)
+    setManualWheelVelocity(0)
+    runtimeApi?.setManualWheelVelocity(0)
+  }
+
+  const selectedPart = selectedPartId ? blueprint.root.parts.find((part) => part.id === selectedPartId) : null
+  const selectedJoint = selectedJointId ? blueprint.root.joints.find((joint) => joint.id === selectedJointId) : null
+
+  const updatePartPosition = useCallback(
+    (partId: string, axis: Axis, value: number) => {
+      setBlueprint((prev) => {
+        const next = cloneBlueprint(prev)
+        const part = next.root.parts.find((candidate) => candidate.id === partId)
+        if (!part) return prev
+        part.transform.position[axis] = value
+        return next
+      })
+    },
+    [],
+  )
+
+  const updatePartRotation = useCallback((partId: string, euler: EulerTriple) => {
+    setBlueprint((prev) => {
+      const next = cloneBlueprint(prev)
+      const part = next.root.parts.find((candidate) => candidate.id === partId)
+      if (!part) return prev
+      part.transform.rotationQuat = eulerDegToQuat(euler)
+      return next
+    })
+  }, [])
+
+  const resetPartTransform = useCallback(
+    (partId: string) => {
+      setBlueprint((prev) => {
+        const baseline = getBlueprintPreset(selectedExample)
+        const baselinePart = baseline.root.parts.find((candidate) => candidate.id === partId)
+        if (!baselinePart) return prev
+        const next = cloneBlueprint(prev)
+        const part = next.root.parts.find((candidate) => candidate.id === partId)
+        if (!part) return prev
+        part.transform = JSON.parse(JSON.stringify(baselinePart.transform))
+        return next
+      })
+    },
+    [selectedExample],
+  )
+
+  const handleJointVelocity = useCallback(
+    (jointId: string, velocity: number) => {
+      setBlueprint((prev) => {
+        const next = cloneBlueprint(prev)
+        const joint = next.root.joints.find((candidate) => candidate.id === jointId)
+        if (!joint) return prev
+        joint.driveOverride = { ...(joint.driveOverride ?? {}), mode: 'velocity', target: velocity }
+        return next
+      })
+      runtimeApi?.setJointMotorTarget(jointId, velocity)
+    },
+    [runtimeApi],
+  )
+
+  const handleJointNudge = useCallback(
+    (jointId: string, velocity: number) => {
+      runtimeApi?.nudgeJoint(jointId, velocity * 2, 350)
+    },
+    [runtimeApi],
+  )
+
+  const handleRuntimeReady = useCallback((api: BlueprintRuntimeApi | null) => {
+    setRuntimeApi(api)
+    if (api) {
+      setManualWheelVelocity(api.getManualWheelVelocity())
+    }
+  }, [])
+
+  const handleManualDriveChange = useCallback(
+    (value: number) => {
+      setManualWheelVelocity(value)
+      runtimeApi?.setManualWheelVelocity(value)
+    },
+    [runtimeApi],
+  )
+
+  const selectedJointTemplateName = useMemo(() => {
+    if (!selectedJoint) return ''
+    return assemblyCatalog.jointTemplates?.[selectedJoint.template]?.id ?? selectedJoint.template
+  }, [selectedJoint])
+
+  const activeExample = blueprintExamples.find((example) => example.id === selectedExample)
+
+  return (
+    <div className="flex min-h-screen flex-col bg-neutral-950 text-neutral-200">
+      <header className="border-b border-neutral-900 bg-neutral-950/90 px-6 py-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold text-white">Assembly Playground</h1>
+            <p className="text-sm text-neutral-400">
+              Build articulated structures with Three.js, React-Three-Fiber, and Rapier. Choose a preset and start
+              editing parts, sockets, and joints live.
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <label className="text-sm">
+              <span className="mr-2 text-neutral-400">Example</span>
+              <select
+                value={selectedExample}
+                onChange={handleExampleChange}
+                className="rounded border border-neutral-700 bg-neutral-900 px-3 py-1 text-sm"
+              >
+                {exampleOptions.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.title}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              onClick={handleResetExample}
+              className="rounded border border-neutral-700 px-3 py-1 text-sm text-neutral-200 hover:border-amber-400 hover:text-amber-200"
+            >
+              Reset Example
+            </button>
+            <label className="flex items-center gap-2 text-xs text-neutral-400">
+              <input
+                type="checkbox"
+                checked={showSockets}
+                onChange={(event) => setShowSockets(event.target.checked)}
+              />
+              Show sockets
+            </label>
+            <label className="flex items-center gap-2 text-xs text-neutral-400">
+              <input
+                type="checkbox"
+                checked={showJointDebug}
+                onChange={(event) => setShowJointDebug(event.target.checked)}
+              />
+              Show joints
+            </label>
+          </div>
+        </div>
+      </header>
+      <div className="flex flex-1 overflow-hidden">
+        <aside className="flex w-72 flex-col border-r border-neutral-900 bg-neutral-950/80">
+          <div className="flex-1 overflow-y-auto p-4">
+            {activeExample ? (
+              <div className="mb-4 rounded border border-neutral-800 bg-neutral-900/60 p-3 text-xs text-neutral-300">
+                {activeExample.summary}
+              </div>
+            ) : null}
+            <div>
+              <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-neutral-400">Parts</h2>
+              <div className="space-y-2">
+                {blueprint.root.parts.map((part) => (
+                  <button
+                    key={part.id}
+                    type="button"
+                    onClick={() => {
+                      setSelectedPartId(part.id)
+                      setSelectedJointId(null)
+                    }}
+                    className={`w-full rounded border px-3 py-2 text-left text-sm transition hover:border-amber-400 hover:text-amber-200 ${selectedPartId === part.id ? 'border-amber-500 bg-amber-500/10 text-amber-200' : 'border-neutral-800 bg-neutral-900/50 text-neutral-200'}`}
+                  >
+                    <span className="block font-semibold">{part.label ?? part.id}</span>
+                    <span className="text-xs text-neutral-400">{part.partId}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="mt-6">
+              <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-neutral-400">Joints</h2>
+              <div className="space-y-2">
+                {blueprint.root.joints.map((joint) => (
+                  <button
+                    key={joint.id}
+                    type="button"
+                    onClick={() => {
+                      setSelectedJointId(joint.id)
+                      setSelectedPartId(null)
+                    }}
+                    className={`w-full rounded border px-3 py-2 text-left text-sm transition hover:border-sky-400 hover:text-sky-200 ${selectedJointId === joint.id ? 'border-sky-500 bg-sky-500/10 text-sky-100' : 'border-neutral-800 bg-neutral-900/50 text-neutral-200'}`}
+                  >
+                    <span className="block font-semibold">{joint.label ?? joint.id}</span>
+                    <span className="text-xs text-neutral-400">{joint.template}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </aside>
+        <main className="flex min-w-0 flex-1 flex-col">
+          <div className="flex-1 min-h-0">
+            <BlueprintCanvas
+              key={`${blueprint.id}-${selectedExample}`}
+              blueprint={blueprint}
+              catalog={assemblyCatalog}
+              selectedPartId={selectedPartId}
+              selectedJointId={selectedJointId}
+              onSelectPart={setSelectedPartId}
+              onSelectJoint={setSelectedJointId}
+              onRuntimeReady={handleRuntimeReady}
+              showSockets={showSockets}
+              showJointDebug={showJointDebug}
+              variantKey={selectedExample}
+            />
+          </div>
+          <div className="border-t border-neutral-900 bg-neutral-950/80 p-4">
+            <BlueprintJsonPreview blueprint={blueprint} />
+          </div>
+        </main>
+        <aside className="w-96 border-l border-neutral-900 bg-neutral-950/85 p-5">
+          {selectedPart && (
+            <section className="space-y-4">
+              <h2 className="text-lg font-semibold text-white">Part Inspector</h2>
+              <PartTransformEditor
+                part={selectedPart}
+                onUpdatePosition={(axis, value) => updatePartPosition(selectedPart.id, axis, value)}
+                onUpdateRotation={(euler) => updatePartRotation(selectedPart.id, euler)}
+                onReset={() => resetPartTransform(selectedPart.id)}
+                onImpulse={(vector) => runtimeApi?.applyImpulseToPart(selectedPart.id, vector)}
+              />
+              <div className="rounded border border-neutral-800 bg-neutral-900/50 p-3 text-xs text-neutral-400">
+                <p>
+                  Selected part: <strong>{selectedPart.partId}</strong>
+                </p>
+                {selectedPart.label ? (
+                  <p>Label: {selectedPart.label}</p>
+                ) : null}
+              </div>
+            </section>
+          )}
+          {selectedJoint && (
+            <section className="mt-6 space-y-4">
+              <h2 className="text-lg font-semibold text-white">Joint Inspector</h2>
+              <JointInspector
+                joint={selectedJoint}
+                templateName={selectedJointTemplateName}
+                onSetVelocity={(velocity) => handleJointVelocity(selectedJoint.id, velocity)}
+                onNudge={(velocity) => handleJointNudge(selectedJoint.id, velocity)}
+              />
+            </section>
+          )}
+          {selectedExample === 'example-car' ? (
+            <section className="mt-8 space-y-3">
+              <h2 className="text-lg font-semibold text-white">Drivetrain Controls</h2>
+              <p className="text-xs text-neutral-400">
+                Use <strong>W/S</strong> to accelerate or reverse. <strong>A/D</strong> adds steering bias. Adjust the base motor
+                target below for cruise control.
+              </p>
+              <label className="flex flex-col gap-2 text-xs text-neutral-300">
+                <span className="font-semibold uppercase tracking-wide text-neutral-400">Manual Motor Target (rad/s)</span>
+                <input
+                  type="range"
+                  min={-12}
+                  max={12}
+                  step={0.1}
+                  value={manualWheelVelocity}
+                  onChange={(event) => handleManualDriveChange(Number.parseFloat(event.target.value))}
+                />
+                <input
+                  type="number"
+                  className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-sm"
+                  value={manualWheelVelocity}
+                  step={0.1}
+                  onChange={(event) => handleManualDriveChange(Number.parseFloat(event.target.value))}
+                />
+              </label>
+            </section>
+          ) : null}
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/src/components/assembly/BlueprintCanvas.tsx
+++ b/src/components/assembly/BlueprintCanvas.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { Suspense } from 'react'
+import { Canvas } from '@react-three/fiber'
+import { Physics } from '@react-three/rapier'
+import { Grid, OrbitControls } from '@react-three/drei'
+import type { Blueprint, Catalog } from '../../types/assembly'
+import { BlueprintScene, type BlueprintRuntimeApi } from './BlueprintScene'
+
+export interface BlueprintCanvasProps {
+  blueprint: Blueprint
+  catalog: Catalog
+  selectedPartId?: string | null
+  selectedJointId?: string | null
+  onSelectPart?: (id: string | null) => void
+  onSelectJoint?: (id: string | null) => void
+  onRuntimeReady?: (runtime: BlueprintRuntimeApi | null) => void
+  showSockets?: boolean
+  showJointDebug?: boolean
+  variantKey?: string
+}
+
+export const BlueprintCanvas = ({
+  blueprint,
+  catalog,
+  selectedPartId,
+  selectedJointId,
+  onSelectPart,
+  onSelectJoint,
+  onRuntimeReady,
+  showSockets,
+  showJointDebug,
+  variantKey,
+}: BlueprintCanvasProps) => {
+  return (
+    <Canvas
+      shadows
+      dpr={[1, 2]}
+      camera={{ position: [9, 7, 9], fov: 45 }}
+      onPointerMissed={() => {
+        onSelectPart?.(null)
+        onSelectJoint?.(null)
+      }}
+    >
+      <color attach="background" args={['#04060a']} />
+      <fog attach="fog" color={'#04060a'} near={35} far={120} />
+      <ambientLight intensity={0.6} />
+      <directionalLight
+        position={[10, 16, 12]}
+        intensity={1.2}
+        castShadow
+        shadow-mapSize-width={2048}
+        shadow-mapSize-height={2048}
+      />
+      <Suspense fallback={null}>
+        <Physics gravity={[0, -9.81, 0]} timeStep="vary">
+          <BlueprintScene
+            blueprint={blueprint}
+            catalog={catalog}
+            selectedPartId={selectedPartId}
+            selectedJointId={selectedJointId}
+            onSelectPart={onSelectPart}
+            onSelectJoint={onSelectJoint}
+            onRuntimeReady={onRuntimeReady}
+            showSockets={showSockets}
+            showJointDebug={showJointDebug}
+            variantKey={variantKey}
+          />
+        </Physics>
+        <Grid
+          args={[100, 100]}
+          cellSize={1}
+          sectionSize={5}
+          fadeDistance={60}
+          fadeStrength={1}
+          infiniteGrid
+        />
+        <OrbitControls
+          makeDefault
+          target={[0, 1.2, 0]}
+          maxPolarAngle={Math.PI * 0.48}
+          minPolarAngle={0.1}
+          maxDistance={60}
+          minDistance={2.4}
+        />
+      </Suspense>
+    </Canvas>
+  )
+}

--- a/src/components/assembly/BlueprintCanvas.tsx
+++ b/src/components/assembly/BlueprintCanvas.tsx
@@ -43,7 +43,7 @@ export const BlueprintCanvas = ({
       }}
     >
       <color attach="background" args={['#04060a']} />
-      <fog attach="fog" color={'#04060a'} near={35} far={120} />
+      <fog attach="fog" args={['#04060a', 35, 120]} />
       <ambientLight intensity={0.6} />
       <directionalLight
         position={[10, 16, 12]}

--- a/src/components/assembly/BlueprintScene.tsx
+++ b/src/components/assembly/BlueprintScene.tsx
@@ -1,0 +1,760 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { MutableRefObject } from 'react'
+import { Color, Quaternion, Vector3 } from 'three'
+import type { Line, Mesh } from 'three'
+import { Html } from '@react-three/drei'
+import { useFrame } from '@react-three/fiber'
+import {
+  BallCollider,
+  CuboidCollider,
+  CylinderCollider,
+  RigidBody,
+  type RigidBodyApi,
+  useRapier,
+} from '@react-three/rapier'
+import type {
+  Blueprint,
+  Catalog,
+  JointInstance,
+  JointTemplate,
+  JointTemplateDrive,
+  PartInstance,
+  SocketDef,
+} from '../../types/assembly'
+import {
+  IDENTITY_QUAT
+  quatToEulerRad,
+  rotateVectorByQuat,
+} from '../../lib/assemblyMath'
+
+export interface BlueprintRuntimeApi {
+  getRigidBody: (id: string) => RigidBodyApi | null
+  setJointMotorTarget: (jointId: string, target: number, maxForce?: number) => void
+  nudgeJoint: (jointId: string, velocity: number, durationMs?: number) => void
+  setManualWheelVelocity: (velocity: number) => void
+  getManualWheelVelocity: () => number
+  applyImpulseToPart: (partId: string, impulse: [number, number, number]) => void
+}
+
+export interface BlueprintSceneProps {
+  blueprint: Blueprint
+  catalog: Catalog
+  selectedPartId?: string | null
+  selectedJointId?: string | null
+  onSelectPart?: (id: string | null) => void
+  onSelectJoint?: (id: string | null) => void
+  onRuntimeReady?: (runtime: BlueprintRuntimeApi | null) => void
+  showSockets?: boolean
+  showJointDebug?: boolean
+  variantKey?: string
+}
+
+type BodyRef = MutableRefObject<RigidBodyApi | null>
+
+type JointHandleInfo = {
+  joint: any
+  template?: JointTemplate
+  drive?: JointTemplateDrive & { target?: number }
+}
+
+const DEFAULT_MOTOR_FORCE = 120
+const KEYBOARD_WHEEL_SPEED = 9
+const TURN_GAIN = 3.2
+
+const toRapierVector = (value: [number, number, number]) => ({ x: value[0], y: value[1], z: value[2] })
+
+const resolveDriveConfig = (template: JointTemplate | undefined, joint: JointInstance) => {
+  const override = joint.driveOverride
+  if (override?.mode === 'velocity') {
+    return { mode: 'velocity', target: override.target ?? 0, maxForce: override.maxForce }
+  }
+  const templateDrive = template?.drive?.find((drive) => drive.mode === 'velocity')
+  if (templateDrive) {
+    return { mode: 'velocity', target: templateDrive.target ?? 0, maxForce: templateDrive.maxForce }
+  }
+  return undefined
+}
+
+const applyMotorWithFallback = (joint: any, target: number, maxForce: number) => {
+  if (!joint) return
+  if (typeof joint.configureMotorVelocity === 'function') {
+    joint.configureMotorVelocity(target, maxForce)
+  } else if (typeof joint.setMotorTargetVelocity === 'function') {
+    joint.setMotorTargetVelocity(target, maxForce)
+  } else if (typeof joint.motorTargetVel === 'function') {
+    joint.motorTargetVel(target, maxForce)
+  }
+}
+
+const useBodyRegistry = () => {
+  const mapRef = useRef(new Map<string, BodyRef>())
+
+  const register = useCallback((id: string, ref: BodyRef | null) => {
+    if (!ref) {
+      mapRef.current.delete(id)
+    } else {
+      mapRef.current.set(id, ref)
+    }
+  }, [])
+
+  const get = useCallback((id: string) => mapRef.current.get(id)?.current ?? null, [])
+
+  const getRef = useCallback((id: string) => mapRef.current.get(id), [])
+
+  const clear = useCallback(() => {
+    mapRef.current.clear()
+  }, [])
+
+  return { register, get, getRef, clear, mapRef }
+}
+
+const PartInstanceBody = ({
+  instance,
+  partDef,
+  selected,
+  onSelect,
+  register,
+  showSockets,
+}: {
+  instance: PartInstance
+  partDef: Catalog['parts'][string]
+  selected: boolean
+  onSelect?: (id: string) => void
+  register: (id: string, ref: BodyRef | null) => void
+  showSockets?: boolean
+}) => {
+  const bodyRef = useRef<RigidBodyApi | null>(null)
+  const [hovered, setHovered] = useState(false)
+
+  useEffect(() => {
+    register(instance.id, bodyRef)
+    return () => {
+      register(instance.id, null)
+    }
+  }, [instance.id, register])
+
+  useEffect(() => {
+    const body = bodyRef.current
+    if (!body) return
+    const [x, y, z] = instance.transform.position
+    const [qx, qy, qz, qw] = instance.transform.rotationQuat
+    body.setTranslation({ x, y, z }, true)
+    body.setRotation({ x: qx, y: qy, z: qz, w: qw }, true)
+  }, [instance.transform.position, instance.transform.rotationQuat])
+
+  const handlePointerDown = useCallback(
+    (event: any) => {
+      event.stopPropagation()
+      onSelect?.(instance.id)
+    },
+    [instance.id, onSelect],
+  )
+
+  const handlePointerOver = useCallback((event: any) => {
+    event.stopPropagation()
+    setHovered(true)
+  }, [])
+
+  const handlePointerOut = useCallback((event: any) => {
+    event.stopPropagation()
+    setHovered(false)
+  }, [])
+
+  const bodyType = partDef.physics?.dynamic ? 'dynamic' : 'fixed'
+  const baseColor = partDef.render?.color ?? '#cfd2d5'
+  const emissive = selected ? new Color('#ffb347') : hovered ? new Color('#66ccff') : new Color('#000000')
+
+  const colliders = partDef.physics?.colliders?.map((collider, index) => {
+    const offsetPosition = collider.offset?.position ?? [0, 0, 0]
+    const offsetRotation = collider.offset?.rotationQuat ?? IDENTITY_QUAT
+    const rotation = quatToEulerRad(offsetRotation)
+    const material = collider.material ?? {}
+    const friction = material.friction ?? (partDef.physics?.dynamic ? 0.7 : 1.0)
+    const restitution = material.restitution ?? (partDef.physics?.dynamic ? 0.1 : 0.05)
+
+    if (collider.shape === 'box') {
+      const [hx, hy, hz] = collider.params as [number, number, number]
+      return (
+        <CuboidCollider
+          key={`collider-${index}`}
+          args={[hx, hy, hz]}
+          position={offsetPosition}
+          rotation={rotation}
+          friction={friction}
+          restitution={restitution}
+        />
+      )
+    }
+    if (collider.shape === 'sphere') {
+      const [radius] = collider.params as [number]
+      return (
+        <BallCollider
+          key={`collider-${index}`}
+          args={[radius]}
+          position={offsetPosition}
+          friction={friction}
+          restitution={restitution}
+        />
+      )
+    }
+    if (collider.shape === 'cylinder') {
+      const [radius, halfHeight] = collider.params as [number, number]
+      return (
+        <CylinderCollider
+          key={`collider-${index}`}
+          args={[halfHeight ?? 0.5, radius ?? 0.5]}
+          position={offsetPosition}
+          rotation={rotation}
+          friction={friction}
+          restitution={restitution}
+        />
+      )
+    }
+    return null
+  })
+
+  const renderShape = () => {
+    const shape = partDef.render?.shape ?? 'box'
+    if (shape === 'box') {
+      const [sx, sy, sz] = partDef.render?.size ?? [1, 1, 1]
+      return (
+        <mesh
+          castShadow
+          receiveShadow
+          onPointerDown={handlePointerDown}
+          onPointerOver={handlePointerOver}
+          onPointerOut={handlePointerOut}
+        >
+          <boxGeometry args={[sx, sy, sz]} />
+          <meshStandardMaterial color={baseColor} metalness={0.1} roughness={0.6} emissive={emissive} emissiveIntensity={selected ? 0.6 : 0.2} />
+        </mesh>
+      )
+    }
+    if (shape === 'cylinder') {
+      const radius = partDef.render?.radius ?? 0.5
+      const height = partDef.render?.height ?? 0.5
+      return (
+        <mesh
+          castShadow
+          receiveShadow
+          rotation={[0, 0, Math.PI / 2]}
+          onPointerDown={handlePointerDown}
+          onPointerOver={handlePointerOver}
+          onPointerOut={handlePointerOut}
+        >
+          <cylinderGeometry args={[radius, radius, height, 24]} />
+          <meshStandardMaterial color={baseColor} metalness={0.2} roughness={0.5} emissive={emissive} emissiveIntensity={selected ? 0.6 : 0.2} />
+        </mesh>
+      )
+    }
+    if (shape === 'panel') {
+      const [sx, sy] = partDef.render?.size ?? [2, 2]
+      return (
+        <mesh
+          receiveShadow
+          rotation={[-Math.PI / 2, 0, 0]}
+          onPointerDown={handlePointerDown}
+          onPointerOver={handlePointerOver}
+          onPointerOut={handlePointerOut}
+        >
+          <planeGeometry args={[sx, sy]} />
+          <meshStandardMaterial color={baseColor} side={2} emissive={emissive} emissiveIntensity={selected ? 0.6 : 0.2} />
+        </mesh>
+      )
+    }
+    return null
+  }
+
+  return (
+    <RigidBody
+      ref={bodyRef}
+      type={bodyType}
+      colliders={false}
+      mass={partDef.physics?.mass}
+      canSleep
+      name={instance.label ?? instance.partId}
+    >
+      {colliders}
+      <group>{renderShape()}</group>
+      {showSockets && (
+        <group>
+          {partDef.sockets.map((socket) => (
+            <mesh key={socket.id} position={socket.frame.position}>
+              <sphereGeometry args={[selected ? 0.11 : 0.08, 12, 12]} />
+              <meshBasicMaterial color={selected ? '#ffd166' : '#57c7ff'} transparent opacity={selected ? 0.9 : 0.6} />
+            </mesh>
+          ))}
+        </group>
+      )}
+      {selected && instance.label ? (
+        <Html
+          position={[0, (partDef.render?.size?.[1] ?? 1.5) * 0.6 + 0.6, 0]}
+          center
+          style={{ pointerEvents: 'none' }}
+        >
+          <div className="rounded bg-black/70 px-2 py-1 text-xs font-semibold text-white shadow-lg">{instance.label}</div>
+        </Html>
+      ) : null}
+    </RigidBody>
+  )
+}
+
+const JointInstanceComponent = ({
+  joint,
+  template,
+  socketA,
+  socketB,
+  bodyA,
+  bodyB,
+  registerJoint,
+}: {
+  joint: JointInstance
+  template: JointTemplate
+  socketA: SocketDef
+  socketB: SocketDef
+  bodyA: BodyRef | undefined
+  bodyB: BodyRef | undefined
+  registerJoint: (id: string, handle: JointHandleInfo | null) => void
+}) => {
+  const { rapier, world } = useRapier()
+
+  useEffect(() => {
+    const bodyAApi = bodyA?.current
+    const bodyBApi = bodyB?.current
+    if (!bodyAApi || !bodyBApi) return
+
+    const rawA = bodyAApi.raw ? bodyAApi.raw() : bodyAApi
+    const rawB = bodyBApi.raw ? bodyBApi.raw() : bodyBApi
+
+    const anchorA = socketA.frame.position
+    const anchorB = socketB.frame.position
+    const baseAxis = template.axis ?? [0, 1, 0]
+    const axis = rotateVectorByQuat(baseAxis, socketA.frame.rotationQuat ?? IDENTITY_QUAT)
+
+    let created: any = null
+
+    if (template.type === 'revolute') {
+      const data = rapier.JointData.revolute(
+        toRapierVector(anchorA),
+        toRapierVector(anchorB),
+        toRapierVector(axis),
+      )
+      created = world.createImpulseJoint(data, rawA, rawB, true)
+    } else if (template.type === 'fixed') {
+      const data = rapier.JointData.fixed(
+        toRapierVector(anchorA),
+        toRapierVector(anchorB),
+        { w: 1, x: 0, y: 0, z: 0 },
+        { w: 1, x: 0, y: 0, z: 0 },
+      )
+      created = world.createImpulseJoint(data, rawA, rawB, true)
+    } else {
+      return () => {}
+    }
+
+    const driveConfig = resolveDriveConfig(template, joint)
+    if (driveConfig?.mode === 'velocity') {
+      applyMotorWithFallback(
+        created,
+        driveConfig.target ?? 0,
+        driveConfig.maxForce ?? DEFAULT_MOTOR_FORCE,
+      )
+    }
+
+    registerJoint(joint.id, { joint: created, template, drive: driveConfig })
+
+    return () => {
+      registerJoint(joint.id, null)
+      if (created) {
+        if (typeof world.removeImpulseJoint === 'function') {
+          world.removeImpulseJoint(created, true)
+        } else if (world.impulseJoints && typeof world.impulseJoints.remove === 'function') {
+          world.impulseJoints.remove(created)
+        }
+      }
+    }
+  }, [bodyA, bodyB, joint, rapier, registerJoint, socketA, socketB, template, world])
+
+  return null
+}
+
+const JointAnchorGizmo = ({
+  joint,
+  socketA,
+  socketB,
+  bodyA,
+  bodyB,
+  selected,
+  onSelect,
+}: {
+  joint: JointInstance
+  socketA: SocketDef
+  socketB: SocketDef
+  bodyA: BodyRef | undefined
+  bodyB: BodyRef | undefined
+  selected: boolean
+  onSelect?: (id: string) => void
+}) => {
+  const sphereARef = useRef<Mesh>(null)
+  const sphereBRef = useRef<Mesh>(null)
+  const lineRef = useRef<Line>(null)
+
+  const updatePositions = useCallback(() => {
+    const bodyAApi = bodyA?.current
+    const bodyBApi = bodyB?.current
+    if (!bodyAApi || !bodyBApi) return
+    const translationA = bodyAApi.translation()
+    const rotationA = bodyAApi.rotation()
+    const translationB = bodyBApi.translation()
+    const rotationB = bodyBApi.rotation()
+
+    const qa = new Quaternion(rotationA.x, rotationA.y, rotationA.z, rotationA.w)
+    const qb = new Quaternion(rotationB.x, rotationB.y, rotationB.z, rotationB.w)
+
+    const worldA = new Vector3().fromArray(socketA.frame.position).applyQuaternion(qa)
+    worldA.add(new Vector3(translationA.x, translationA.y, translationA.z))
+
+    const worldB = new Vector3().fromArray(socketB.frame.position).applyQuaternion(qb)
+    worldB.add(new Vector3(translationB.x, translationB.y, translationB.z))
+
+    sphereARef.current?.position.copy(worldA)
+    sphereBRef.current?.position.copy(worldB)
+
+    const positions = lineRef.current?.geometry.getAttribute('position')
+    if (positions) {
+      positions.setXYZ(0, worldA.x, worldA.y, worldA.z)
+      positions.setXYZ(1, worldB.x, worldB.y, worldB.z)
+      positions.needsUpdate = true
+    }
+  }, [bodyA, bodyB, socketA.frame.position, socketB.frame.position])
+
+  useFrame(updatePositions)
+
+  const handleSelect = useCallback(
+    (event: any) => {
+      event.stopPropagation()
+      onSelect?.(joint.id)
+    },
+    [joint.id, onSelect],
+  )
+
+  const color = selected ? '#ffaf40' : '#6dd5ff'
+  const scale = selected ? 1.2 : 1
+
+  return (
+    <group>
+      <mesh ref={sphereARef} scale={scale} onPointerDown={handleSelect}>
+        <sphereGeometry args={[0.12, 12, 12]} />
+        <meshBasicMaterial color={color} />
+      </mesh>
+      <mesh ref={sphereBRef} scale={scale} onPointerDown={handleSelect}>
+        <sphereGeometry args={[0.1, 12, 12]} />
+        <meshBasicMaterial color={color} />
+      </mesh>
+      <line ref={lineRef} onPointerDown={handleSelect}>
+        <bufferGeometry>
+          <bufferAttribute attach="attributes-position" count={2} itemSize={3} array={new Float32Array(6)} />
+        </bufferGeometry>
+        <lineBasicMaterial color={color} linewidth={selected ? 2 : 1} />
+      </line>
+    </group>
+  )
+}
+
+export const BlueprintScene = ({
+  blueprint,
+  catalog,
+  selectedPartId,
+  selectedJointId,
+  onSelectPart,
+  onSelectJoint,
+  onRuntimeReady,
+  showSockets,
+  showJointDebug = true,
+  variantKey,
+}: BlueprintSceneProps) => {
+  const parts = blueprint.root.parts
+  const joints = blueprint.root.joints
+
+  const partLookup = useMemo(() => new Map(parts.map((part) => [part.id, part])), [parts])
+
+  const bodyRegistry = useBodyRegistry()
+  const jointHandlesRef = useRef(new Map<string, JointHandleInfo>())
+  const carControlRef = useRef({
+    manualVelocity: 0,
+    throttle: 0,
+    turn: 0,
+    keys: { forward: false, backward: false, left: false, right: false },
+  })
+
+  useEffect(() => {
+    bodyRegistry.clear()
+    jointHandlesRef.current.clear()
+    carControlRef.current.manualVelocity = 0
+    carControlRef.current.throttle = 0
+    carControlRef.current.turn = 0
+  }, [blueprint.id, bodyRegistry])
+
+  const registerJoint = useCallback((id: string, handle: JointHandleInfo | null) => {
+    if (!handle) {
+      jointHandlesRef.current.delete(id)
+    } else {
+      jointHandlesRef.current.set(id, handle)
+    }
+  }, [])
+
+  useEffect(() => {
+    joints.forEach((joint) => {
+      const handle = jointHandlesRef.current.get(joint.id)
+      if (!handle) return
+      const drive = resolveDriveConfig(handle.template, joint)
+      if (drive?.mode === 'velocity') {
+        applyMotorWithFallback(
+          handle.joint,
+          joint.driveOverride?.target ?? drive.target ?? 0,
+          drive.maxForce ?? DEFAULT_MOTOR_FORCE,
+        )
+        handle.drive = drive
+      }
+    })
+  }, [joints])
+
+  const wheelJointIds = useMemo(
+    () =>
+      joints
+        .filter((joint) => joint.template === 'hinge_wheel_motor_v1')
+        .map((joint) => joint.id),
+    [joints],
+  )
+
+  const wheelJointSides = useMemo(() => {
+    const map = new Map<string, 'left' | 'right'>()
+    wheelJointIds.forEach((jointId) => {
+      const joint = joints.find((candidate) => candidate.id === jointId)
+      if (!joint) return
+      const wheelInstance = partLookup.get(joint.b.partInstanceId)
+      if (!wheelInstance) return
+      const [x] = wheelInstance.transform.position
+      map.set(jointId, x < 0 ? 'left' : 'right')
+    })
+    return map
+  }, [joints, partLookup, wheelJointIds])
+
+  useEffect(() => {
+    if (variantKey !== 'example-car') return
+    const pressed = carControlRef.current.keys
+
+    const updateState = () => {
+      const forward = (pressed.forward ? 1 : 0) - (pressed.backward ? 1 : 0)
+      const turn = (pressed.left ? 1 : 0) - (pressed.right ? 1 : 0)
+      carControlRef.current.throttle = forward
+      carControlRef.current.turn = turn
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      switch (event.code) {
+        case 'KeyW':
+        case 'ArrowUp':
+          pressed.forward = true
+          break
+        case 'KeyS':
+        case 'ArrowDown':
+          pressed.backward = true
+          break
+        case 'KeyA':
+        case 'ArrowLeft':
+          pressed.left = true
+          break
+        case 'KeyD':
+        case 'ArrowRight':
+          pressed.right = true
+          break
+        default:
+          return
+      }
+      updateState()
+    }
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      switch (event.code) {
+        case 'KeyW':
+        case 'ArrowUp':
+          pressed.forward = false
+          break
+        case 'KeyS':
+        case 'ArrowDown':
+          pressed.backward = false
+          break
+        case 'KeyA':
+        case 'ArrowLeft':
+          pressed.left = false
+          break
+        case 'KeyD':
+        case 'ArrowRight':
+          pressed.right = false
+          break
+        default:
+          return
+      }
+      updateState()
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', handleKeyUp)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', handleKeyUp)
+      carControlRef.current.keys.forward = false
+      carControlRef.current.keys.backward = false
+      carControlRef.current.keys.left = false
+      carControlRef.current.keys.right = false
+      carControlRef.current.throttle = 0
+      carControlRef.current.turn = 0
+    }
+  }, [variantKey])
+
+  useFrame(() => {
+    if (variantKey !== 'example-car') return
+    const control = carControlRef.current
+    const baseVelocity = control.manualVelocity + control.throttle * KEYBOARD_WHEEL_SPEED
+    const turnBias = control.turn * TURN_GAIN
+
+    wheelJointIds.forEach((jointId) => {
+      const handle = jointHandlesRef.current.get(jointId)
+      if (!handle) return
+      const side = wheelJointSides.get(jointId)
+      const driveForce = handle.drive?.maxForce ?? DEFAULT_MOTOR_FORCE * 5
+      const target = side === 'left' ? baseVelocity - turnBias : baseVelocity + turnBias
+      applyMotorWithFallback(handle.joint, target, driveForce)
+    })
+  })
+
+  const setJointMotorTarget = useCallback((jointId: string, target: number, maxForce?: number) => {
+    const handle = jointHandlesRef.current.get(jointId)
+    if (!handle) return
+    const force = maxForce ?? handle.drive?.maxForce ?? DEFAULT_MOTOR_FORCE
+    applyMotorWithFallback(handle.joint, target, force)
+    if (handle.drive) {
+      handle.drive.target = target
+      handle.drive.maxForce = force
+    }
+  }, [])
+
+  const nudgeJoint = useCallback((jointId: string, velocity: number, durationMs = 400) => {
+    const handle = jointHandlesRef.current.get(jointId)
+    if (!handle) return
+    const force = handle.drive?.maxForce ?? DEFAULT_MOTOR_FORCE
+    applyMotorWithFallback(handle.joint, velocity, force)
+    window.setTimeout(() => {
+      applyMotorWithFallback(handle.joint, 0, force)
+    }, durationMs)
+  }, [])
+
+  const setManualWheelVelocity = useCallback((velocity: number) => {
+    carControlRef.current.manualVelocity = velocity
+  }, [])
+
+  const getManualWheelVelocity = useCallback(() => carControlRef.current.manualVelocity, [])
+
+  const applyImpulseToPart = useCallback((partId: string, impulse: [number, number, number]) => {
+    const body = bodyRegistry.get(partId)
+    if (!body) return
+    body.applyImpulse({ x: impulse[0], y: impulse[1], z: impulse[2] }, true)
+  }, [bodyRegistry])
+
+  useEffect(() => {
+    if (!onRuntimeReady) return
+    const runtime: BlueprintRuntimeApi = {
+      getRigidBody: bodyRegistry.get,
+      setJointMotorTarget,
+      nudgeJoint,
+      setManualWheelVelocity,
+      getManualWheelVelocity,
+      applyImpulseToPart,
+    }
+    onRuntimeReady(runtime)
+    return () => onRuntimeReady(null)
+  }, [
+    applyImpulseToPart,
+    bodyRegistry.get,
+    getManualWheelVelocity,
+    nudgeJoint,
+    onRuntimeReady,
+    setJointMotorTarget,
+    setManualWheelVelocity,
+  ])
+
+  const getSocket = useCallback(
+    (partInstanceId: string, socketId: string) => {
+      const instance = partLookup.get(partInstanceId)
+      if (!instance) return undefined
+      const partDef = catalog.parts[instance.partId]
+      return partDef?.sockets.find((socket) => socket.id === socketId)
+    },
+    [catalog.parts, partLookup],
+  )
+
+  return (
+    <group>
+      <RigidBody type="fixed" colliders={false}>
+        <CuboidCollider args={[40, 0.05, 40]} position={[0, -0.1, 0]} friction={1.4} restitution={0.05} />
+        <mesh receiveShadow rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.1, 0]}>
+          <planeGeometry args={[80, 80]} />
+          <meshStandardMaterial color="#2a2d33" roughness={0.9} metalness={0} />
+        </mesh>
+      </RigidBody>
+      {parts.map((instance) => {
+        const partDef = catalog.parts[instance.partId]
+        if (!partDef) return null
+        return (
+          <PartInstanceBody
+            key={instance.id}
+            instance={instance}
+            partDef={partDef}
+            selected={selectedPartId === instance.id}
+            onSelect={(id) => onSelectPart?.(id)}
+            register={(id, ref) => bodyRegistry.register(id, ref)}
+            showSockets={showSockets}
+          />
+        )
+      })}
+      {joints.map((joint) => {
+        const template = catalog.jointTemplates?.[joint.template]
+        if (!template) return null
+        const socketA = getSocket(joint.a.partInstanceId, joint.a.socketId)
+        const socketB = getSocket(joint.b.partInstanceId, joint.b.socketId)
+        if (!socketA || !socketB) return null
+        const bodyA = bodyRegistry.getRef(joint.a.partInstanceId)
+        const bodyB = bodyRegistry.getRef(joint.b.partInstanceId)
+        if (!bodyA || !bodyB) return null
+        return (
+          <group key={joint.id}>
+            <JointInstanceComponent
+              joint={joint}
+              template={template}
+              socketA={socketA}
+              socketB={socketB}
+              bodyA={bodyA}
+              bodyB={bodyB}
+              registerJoint={registerJoint}
+            />
+            {showJointDebug ? (
+              <JointAnchorGizmo
+                joint={joint}
+                socketA={socketA}
+                socketB={socketB}
+                bodyA={bodyA}
+                bodyB={bodyB}
+                selected={selectedJointId === joint.id}
+                onSelect={(id) => onSelectJoint?.(id)}
+              />
+            ) : null}
+          </group>
+        )
+      })}
+    </group>
+  )
+}

--- a/src/lib/assemblyContent.ts
+++ b/src/lib/assemblyContent.ts
@@ -1,0 +1,510 @@
+import type { Blueprint, Catalog, PartInstance, PartDef, JointInstance } from '../types/assembly'
+import { IDENTITY_QUAT } from './assemblyMath'
+
+type BlueprintExample = {
+  id: string
+  title: string
+  summary: string
+  blueprint: Blueprint
+}
+
+const SQRT_HALF = Math.SQRT1_2
+const QUAT_Y90: [number, number, number, number] = [0, SQRT_HALF, 0, SQRT_HALF]
+const QUAT_NEG_Y90: [number, number, number, number] = [0, -SQRT_HALF, 0, SQRT_HALF]
+
+const buildingParts: Record<string, PartDef> = {
+  'core:floor_panel_v1': {
+    id: 'core:floor_panel_v1',
+    version: '1.0.0',
+    name: 'Floor Panel 4m',
+    category: 'structural',
+    render: { shape: 'box', size: [4, 0.2, 4], color: '#78736b' },
+    physics: {
+      dynamic: false,
+      colliders: [{ shape: 'box', params: [2, 0.1, 2] }],
+    },
+    sockets: [
+      {
+        id: 'north_edge',
+        kind: 'structural',
+        type: 'grid:4m',
+        frame: { position: [0, 0.1, 2], rotationQuat: IDENTITY_QUAT },
+        allowedMates: ['grid:4m'],
+      },
+      {
+        id: 'south_edge',
+        kind: 'structural',
+        type: 'grid:4m',
+        frame: { position: [0, 0.1, -2], rotationQuat: IDENTITY_QUAT },
+        allowedMates: ['grid:4m'],
+      },
+      {
+        id: 'east_edge',
+        kind: 'structural',
+        type: 'grid:4m',
+        frame: { position: [2, 0.1, 0], rotationQuat: QUAT_Y90 },
+        allowedMates: ['grid:4m'],
+      },
+      {
+        id: 'west_edge',
+        kind: 'structural',
+        type: 'grid:4m',
+        frame: { position: [-2, 0.1, 0], rotationQuat: QUAT_NEG_Y90 },
+        allowedMates: ['grid:4m'],
+      },
+      {
+        id: 'roof_mount',
+        kind: 'structural',
+        type: 'roof:plate',
+        frame: { position: [0, 0.1, 0], rotationQuat: IDENTITY_QUAT },
+      },
+    ],
+    metadata: {
+      tags: ['building', 'structural'],
+      description: '4x4m reinforced foundation slab',
+    },
+  },
+  'core:wall_panel_v1': {
+    id: 'core:wall_panel_v1',
+    version: '1.0.0',
+    name: 'Wall Panel',
+    category: 'structural',
+    render: { shape: 'box', size: [4, 2.5, 0.2], color: '#bcb6aa' },
+    physics: {
+      dynamic: false,
+      colliders: [{ shape: 'box', params: [2, 1.25, 0.1] }],
+    },
+    sockets: [
+      {
+        id: 'bottom_edge',
+        kind: 'structural',
+        type: 'grid:4m',
+        frame: { position: [0, -1.25, 0], rotationQuat: IDENTITY_QUAT },
+        allowedMates: ['grid:4m'],
+      },
+      {
+        id: 'top_edge',
+        kind: 'structural',
+        type: 'roof:plate',
+        frame: { position: [0, 1.25, 0], rotationQuat: IDENTITY_QUAT },
+      },
+    ],
+    metadata: {
+      tags: ['building', 'wall'],
+    },
+  },
+  'core:wall_panel_door_v1': {
+    id: 'core:wall_panel_door_v1',
+    version: '1.0.0',
+    name: 'Wall Panel with Door Frame',
+    category: 'structural',
+    render: { shape: 'box', size: [4, 2.5, 0.2], color: '#c6c0b0' },
+    physics: {
+      dynamic: false,
+      colliders: [{ shape: 'box', params: [2, 1.25, 0.1] }],
+    },
+    sockets: [
+      {
+        id: 'bottom_edge',
+        kind: 'structural',
+        type: 'grid:4m',
+        frame: { position: [0, -1.25, 0], rotationQuat: IDENTITY_QUAT },
+        allowedMates: ['grid:4m'],
+      },
+      {
+        id: 'door_hinge',
+        kind: 'mechanical',
+        type: 'hinge:standard',
+        frame: { position: [-0.5, 0, -0.025], rotationQuat: IDENTITY_QUAT },
+        defaultJoint: 'hinge_door_v1',
+      },
+      {
+        id: 'top_edge',
+        kind: 'structural',
+        type: 'roof:plate',
+        frame: { position: [0, 1.25, 0], rotationQuat: IDENTITY_QUAT },
+      },
+    ],
+    metadata: {
+      tags: ['building', 'wall', 'door'],
+    },
+  },
+  'core:roof_panel_v1': {
+    id: 'core:roof_panel_v1',
+    version: '1.0.0',
+    name: 'Roof Panel',
+    category: 'structural',
+    render: { shape: 'box', size: [4.2, 0.2, 4.2], color: '#4f5358' },
+    physics: {
+      dynamic: false,
+      colliders: [{ shape: 'box', params: [2.1, 0.1, 2.1] }],
+    },
+    sockets: [
+      {
+        id: 'underside_center',
+        kind: 'structural',
+        type: 'roof:plate',
+        frame: { position: [0, -0.1, 0], rotationQuat: IDENTITY_QUAT },
+      },
+    ],
+    metadata: {
+      tags: ['building', 'roof'],
+    },
+  },
+  'core:door_panel_v1': {
+    id: 'core:door_panel_v1',
+    version: '1.0.0',
+    name: 'Wooden Door',
+    category: 'structural',
+    render: { shape: 'box', size: [1, 2.2, 0.05], color: '#8b5a3c' },
+    physics: {
+      dynamic: true,
+      mass: 18,
+      colliders: [{ shape: 'box', params: [0.5, 1.1, 0.025] }],
+    },
+    sockets: [
+      {
+        id: 'hinge',
+        kind: 'mechanical',
+        type: 'hinge:standard',
+        frame: { position: [0.5, 0, 0], rotationQuat: IDENTITY_QUAT },
+        allowedMates: ['hinge:standard'],
+      },
+    ],
+    metadata: {
+      tags: ['door', 'dynamic'],
+    },
+  },
+}
+
+const vehicleParts: Record<string, PartDef> = {
+  'veh:chassis_small_v1': {
+    id: 'veh:chassis_small_v1',
+    version: '1.0.0',
+    name: 'Compact Chassis',
+    category: 'mechanical',
+    render: { shape: 'box', size: [2.6, 0.4, 1.6], color: '#2b4255' },
+    physics: {
+      dynamic: true,
+      mass: 240,
+      colliders: [{ shape: 'box', params: [1.3, 0.2, 0.8] }],
+    },
+    sockets: [
+      {
+        id: 'front_left_axle',
+        kind: 'mechanical',
+        type: 'axle:wheel90',
+        frame: { position: [-1.0, -0.25, 1.2], rotationQuat: IDENTITY_QUAT },
+        defaultJoint: 'hinge_wheel_motor_v1',
+      },
+      {
+        id: 'front_right_axle',
+        kind: 'mechanical',
+        type: 'axle:wheel90',
+        frame: { position: [1.0, -0.25, 1.2], rotationQuat: IDENTITY_QUAT },
+        defaultJoint: 'hinge_wheel_motor_v1',
+      },
+      {
+        id: 'rear_left_axle',
+        kind: 'mechanical',
+        type: 'axle:wheel90',
+        frame: { position: [-1.0, -0.25, -1.2], rotationQuat: IDENTITY_QUAT },
+        defaultJoint: 'hinge_wheel_motor_v1',
+      },
+      {
+        id: 'rear_right_axle',
+        kind: 'mechanical',
+        type: 'axle:wheel90',
+        frame: { position: [1.0, -0.25, -1.2], rotationQuat: IDENTITY_QUAT },
+        defaultJoint: 'hinge_wheel_motor_v1',
+      },
+      {
+        id: 'roof_rack',
+        kind: 'structural',
+        type: 'grid:1m',
+        frame: { position: [0, 0.2, 0], rotationQuat: IDENTITY_QUAT },
+      },
+    ],
+    metadata: {
+      tags: ['vehicle', 'dynamic'],
+    },
+  },
+  'veh:wheel_90cm_v1': {
+    id: 'veh:wheel_90cm_v1',
+    version: '1.0.0',
+    name: '90cm Traction Wheel',
+    category: 'mechanical',
+    render: { shape: 'cylinder', radius: 0.45, height: 0.3, color: '#222222' },
+    physics: {
+      dynamic: true,
+      mass: 32,
+      colliders: [
+        { shape: 'cylinder', params: [0.45, 0.15], offset: { position: [0, 0, 0], rotationQuat: [0, 0, 0.7071068, 0.7071068] } },
+      ],
+    },
+    sockets: [
+      {
+        id: 'axle',
+        kind: 'mechanical',
+        type: 'axle:wheel90',
+        frame: { position: [0, 0, 0], rotationQuat: IDENTITY_QUAT },
+        allowedMates: ['axle:wheel90'],
+      },
+    ],
+    components: [
+      { kind: 'Wheel', radius: 0.45, width: 0.3 },
+      { kind: 'Motor', axis: 'x', nominalPower: 2500, maxTorque: 280, maxRPM: 600 },
+    ],
+    metadata: {
+      tags: ['vehicle', 'wheel', 'motor'],
+    },
+  },
+}
+
+const catalog: Catalog = {
+  id: 'demo:assembly-catalog',
+  version: '0.1.0',
+  parts: {
+    ...buildingParts,
+    ...vehicleParts,
+  },
+  jointTemplates: {
+    fixed_weld_v1: {
+      id: 'fixed_weld_v1',
+      type: 'fixed',
+      friction: 1,
+    },
+    hinge_door_v1: {
+      id: 'hinge_door_v1',
+      type: 'revolute',
+      axis: [0, 1, 0],
+      friction: 2,
+    },
+    hinge_wheel_motor_v1: {
+      id: 'hinge_wheel_motor_v1',
+      type: 'revolute',
+      axis: [1, 0, 0],
+      friction: 0.2,
+      drive: [
+        { mode: 'velocity', target: 0, maxForce: 1200 },
+      ],
+    },
+  },
+}
+
+const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value))
+
+const houseParts: PartInstance[] = [
+  {
+    id: 'pi_floor',
+    partId: 'core:floor_panel_v1',
+    transform: { position: [0, 0, 0], rotationQuat: IDENTITY_QUAT },
+    label: 'Floor Slab',
+  },
+  {
+    id: 'pi_wall_north',
+    partId: 'core:wall_panel_door_v1',
+    transform: { position: [0, 1.25, 2], rotationQuat: IDENTITY_QUAT },
+    label: 'North Wall',
+  },
+  {
+    id: 'pi_wall_south',
+    partId: 'core:wall_panel_v1',
+    transform: { position: [0, 1.25, -2], rotationQuat: IDENTITY_QUAT },
+    label: 'South Wall',
+  },
+  {
+    id: 'pi_wall_east',
+    partId: 'core:wall_panel_v1',
+    transform: { position: [2, 1.25, 0], rotationQuat: QUAT_Y90 },
+    label: 'East Wall',
+  },
+  {
+    id: 'pi_wall_west',
+    partId: 'core:wall_panel_v1',
+    transform: { position: [-2, 1.25, 0], rotationQuat: QUAT_Y90 },
+    label: 'West Wall',
+  },
+  {
+    id: 'pi_roof',
+    partId: 'core:roof_panel_v1',
+    transform: { position: [0, 2.6, 0], rotationQuat: IDENTITY_QUAT },
+    label: 'Roof',
+  },
+  {
+    id: 'pi_door',
+    partId: 'core:door_panel_v1',
+    transform: { position: [-1, 1.1, 1.975], rotationQuat: IDENTITY_QUAT },
+    label: 'Door',
+  },
+]
+
+const houseJoints: JointInstance[] = [
+  {
+    id: 'joint_floor_north',
+    a: { partInstanceId: 'pi_floor', socketId: 'north_edge' },
+    b: { partInstanceId: 'pi_wall_north', socketId: 'bottom_edge' },
+    template: 'fixed_weld_v1',
+  },
+  {
+    id: 'joint_floor_south',
+    a: { partInstanceId: 'pi_floor', socketId: 'south_edge' },
+    b: { partInstanceId: 'pi_wall_south', socketId: 'bottom_edge' },
+    template: 'fixed_weld_v1',
+  },
+  {
+    id: 'joint_floor_east',
+    a: { partInstanceId: 'pi_floor', socketId: 'east_edge' },
+    b: { partInstanceId: 'pi_wall_east', socketId: 'bottom_edge' },
+    template: 'fixed_weld_v1',
+  },
+  {
+    id: 'joint_floor_west',
+    a: { partInstanceId: 'pi_floor', socketId: 'west_edge' },
+    b: { partInstanceId: 'pi_wall_west', socketId: 'bottom_edge' },
+    template: 'fixed_weld_v1',
+  },
+  {
+    id: 'joint_roof',
+    a: { partInstanceId: 'pi_roof', socketId: 'underside_center' },
+    b: { partInstanceId: 'pi_floor', socketId: 'roof_mount' },
+    template: 'fixed_weld_v1',
+  },
+  {
+    id: 'joint_door',
+    a: { partInstanceId: 'pi_wall_north', socketId: 'door_hinge' },
+    b: { partInstanceId: 'pi_door', socketId: 'hinge' },
+    template: 'hinge_door_v1',
+    driveOverride: { mode: 'velocity', target: 0, maxForce: 60 },
+  },
+]
+
+const houseBlueprint: Blueprint = {
+  id: 'bp:demo_house_v1',
+  name: 'Hinged House',
+  version: '0.1.0',
+  root: {
+    id: 'asm:house_root',
+    name: 'House Assembly',
+    parts: houseParts,
+    joints: houseJoints,
+    bakePolicy: 'articulated',
+  },
+}
+
+const carParts: PartInstance[] = [
+  {
+    id: 'pi_car_ground',
+    partId: 'core:floor_panel_v1',
+    transform: { position: [0, -0.1, 0], rotationQuat: IDENTITY_QUAT },
+    label: 'Service Pad',
+  },
+  {
+    id: 'pi_chassis',
+    partId: 'veh:chassis_small_v1',
+    transform: { position: [0, 0.6, 0], rotationQuat: IDENTITY_QUAT },
+    label: 'Chassis',
+  },
+  {
+    id: 'pi_wheel_fl',
+    partId: 'veh:wheel_90cm_v1',
+    transform: { position: [-1.0, 0.35, 1.2], rotationQuat: IDENTITY_QUAT },
+    label: 'Front Left Wheel',
+  },
+  {
+    id: 'pi_wheel_fr',
+    partId: 'veh:wheel_90cm_v1',
+    transform: { position: [1.0, 0.35, 1.2], rotationQuat: IDENTITY_QUAT },
+    label: 'Front Right Wheel',
+  },
+  {
+    id: 'pi_wheel_rl',
+    partId: 'veh:wheel_90cm_v1',
+    transform: { position: [-1.0, 0.35, -1.2], rotationQuat: IDENTITY_QUAT },
+    label: 'Rear Left Wheel',
+  },
+  {
+    id: 'pi_wheel_rr',
+    partId: 'veh:wheel_90cm_v1',
+    transform: { position: [1.0, 0.35, -1.2], rotationQuat: IDENTITY_QUAT },
+    label: 'Rear Right Wheel',
+  },
+]
+
+const motorDrive = { mode: 'velocity' as const, target: 0, maxForce: 800 }
+
+const carJoints: JointInstance[] = [
+  {
+    id: 'joint_fl',
+    a: { partInstanceId: 'pi_chassis', socketId: 'front_left_axle' },
+    b: { partInstanceId: 'pi_wheel_fl', socketId: 'axle' },
+    template: 'hinge_wheel_motor_v1',
+    driveOverride: motorDrive,
+    articulationGroup: 'car_drivetrain',
+  },
+  {
+    id: 'joint_fr',
+    a: { partInstanceId: 'pi_chassis', socketId: 'front_right_axle' },
+    b: { partInstanceId: 'pi_wheel_fr', socketId: 'axle' },
+    template: 'hinge_wheel_motor_v1',
+    driveOverride: motorDrive,
+    articulationGroup: 'car_drivetrain',
+  },
+  {
+    id: 'joint_rl',
+    a: { partInstanceId: 'pi_chassis', socketId: 'rear_left_axle' },
+    b: { partInstanceId: 'pi_wheel_rl', socketId: 'axle' },
+    template: 'hinge_wheel_motor_v1',
+    driveOverride: motorDrive,
+    articulationGroup: 'car_drivetrain',
+  },
+  {
+    id: 'joint_rr',
+    a: { partInstanceId: 'pi_chassis', socketId: 'rear_right_axle' },
+    b: { partInstanceId: 'pi_wheel_rr', socketId: 'axle' },
+    template: 'hinge_wheel_motor_v1',
+    driveOverride: motorDrive,
+    articulationGroup: 'car_drivetrain',
+  },
+]
+
+const carBlueprint: Blueprint = {
+  id: 'bp:demo_car_v1',
+  name: 'Motorized Rover',
+  version: '0.1.0',
+  root: {
+    id: 'asm:car_root',
+    name: 'Rover Assembly',
+    parts: carParts,
+    joints: carJoints,
+    bakePolicy: 'articulated',
+  },
+}
+
+export const assemblyCatalog = catalog
+
+export const blueprintExamples: BlueprintExample[] = [
+  {
+    id: 'example-house',
+    title: 'Hinged House',
+    summary: 'Structural assembly with a hinged door. Rotate the door or move wall panels to explore sockets.',
+    blueprint: houseBlueprint,
+  },
+  {
+    id: 'example-car',
+    title: 'Simple Motorized Rover',
+    summary: 'Four-wheel articulated rover powered by rapier motorized hinge joints. Drive with WASD keys.',
+    blueprint: carBlueprint,
+  },
+]
+
+export const getBlueprintPreset = (exampleId: string): Blueprint => {
+  const example = blueprintExamples.find((candidate) => candidate.id === exampleId)
+  if (!example) {
+    throw new Error(`Unknown blueprint preset ${exampleId}`)
+  }
+  return clone(example.blueprint)
+}
+
+export const listBlueprintOptions = () =>
+  blueprintExamples.map((example) => ({ id: example.id, title: example.title, summary: example.summary }))

--- a/src/lib/assemblyMath.ts
+++ b/src/lib/assemblyMath.ts
@@ -1,0 +1,85 @@
+import { Euler, Quaternion, Vector3 } from 'three'
+import type { Transform } from '../types/assembly'
+
+export const IDENTITY_QUAT: [number, number, number, number] = [0, 0, 0, 1]
+
+export const degToRad = (deg: number) => (deg * Math.PI) / 180
+export const radToDeg = (rad: number) => (rad * 180) / Math.PI
+
+export const quatArrayToQuaternion = (quat: [number, number, number, number]) => {
+  const [x, y, z, w] = quat
+  return new Quaternion(x, y, z, w)
+}
+
+export const quaternionToArray = (quat: Quaternion): [number, number, number, number] => [
+  quat.x,
+  quat.y,
+  quat.z,
+  quat.w,
+]
+
+export const transformPoint = (transform: Transform, localPoint: [number, number, number]) => {
+  const quat = quatArrayToQuaternion(transform.rotationQuat)
+  const worldPos = new Vector3().fromArray(localPoint).applyQuaternion(quat)
+  worldPos.add(new Vector3().fromArray(transform.position))
+  return worldPos
+}
+
+export const multiplyTransforms = (a: Transform, b: Transform): Transform => {
+  const qa = quatArrayToQuaternion(a.rotationQuat)
+  const qb = quatArrayToQuaternion(b.rotationQuat)
+  const combinedQuat = qa.clone().multiply(qb)
+  const rotatedPosition = new Vector3().fromArray(b.position).applyQuaternion(qa)
+  const combinedPosition = rotatedPosition.add(new Vector3().fromArray(a.position))
+  return {
+    position: [combinedPosition.x, combinedPosition.y, combinedPosition.z],
+    rotationQuat: [combinedQuat.x, combinedQuat.y, combinedQuat.z, combinedQuat.w],
+  }
+}
+
+export const quatToEulerDeg = (quat: [number, number, number, number]): [number, number, number] => {
+  const q = quatArrayToQuaternion(quat)
+  const euler = new Euler().setFromQuaternion(q, 'XYZ')
+  return [radToDeg(euler.x), radToDeg(euler.y), radToDeg(euler.z)]
+}
+
+export const eulerDegToQuat = (eulerDeg: [number, number, number]): [number, number, number, number] => {
+  const [x, y, z] = eulerDeg
+  const euler = new Euler(degToRad(x), degToRad(y), degToRad(z), 'XYZ')
+  const quat = new Quaternion().setFromEuler(euler)
+  return [quat.x, quat.y, quat.z, quat.w]
+}
+
+export const normalizeQuat = (quat: [number, number, number, number]): [number, number, number, number] => {
+  const q = quatArrayToQuaternion(quat)
+  q.normalize()
+  return [q.x, q.y, q.z, q.w]
+}
+
+export const quatToEulerRad = (quat: [number, number, number, number]): [number, number, number] => {
+  const q = quatArrayToQuaternion(quat)
+  const euler = new Euler().setFromQuaternion(q, 'XYZ')
+  return [euler.x, euler.y, euler.z]
+}
+
+export const rotateVectorByQuat = (
+  vector: [number, number, number],
+  quat: [number, number, number, number],
+): [number, number, number] => {
+  const q = quatArrayToQuaternion(quat)
+  const result = new Vector3().fromArray(vector).applyQuaternion(q)
+  return [result.x, result.y, result.z]
+}
+
+export const ensureQuaternionNormalized = (
+  quat: [number, number, number, number],
+): [number, number, number, number] => {
+  const q = quatArrayToQuaternion(quat)
+  if (Math.abs(q.lengthSq() - 1) < 1e-5) {
+    return quat
+  }
+  q.normalize()
+  return [q.x, q.y, q.z, q.w]
+}
+
+export const vectorToArray = (vector: Vector3): [number, number, number] => [vector.x, vector.y, vector.z]

--- a/src/types/assembly.ts
+++ b/src/types/assembly.ts
@@ -1,0 +1,345 @@
+export type SemVer = `${number}.${number}.${number}`
+export type UUID = string
+export type meters = number
+export type kilograms = number
+export type radians = number
+export type watts = number
+
+export interface Transform {
+  position: [number, number, number]
+  rotationQuat: [number, number, number, number]
+  scale?: [number, number, number]
+}
+
+export interface LODRef {
+  gltf: string
+  node?: string
+  screenCoverage?: number
+}
+
+export interface RenderDef {
+  gltf?: string
+  node?: string
+  scale?: number
+  icon?: string
+  lod?: LODRef[]
+  /** Optional simple shape helpers for prototyping without external assets */
+  shape?: 'box' | 'cylinder' | 'panel'
+  size?: [number, number, number]
+  radius?: number
+  height?: number
+  color?: string
+}
+
+export interface ColliderDef {
+  shape: 'box' | 'sphere' | 'capsule' | 'cylinder' | 'convexHull' | 'mesh'
+  params: number[]
+  offset?: Transform
+  material?: {
+    friction?: number
+    restitution?: number
+  }
+}
+
+export interface SocketDef {
+  id: string
+  kind: 'structural' | 'mechanical' | 'electrical' | 'fluid' | 'inventory' | 'decorative'
+  type: string
+  gender?: 'male' | 'female' | 'neutral'
+  tags?: string[]
+  frame: Transform
+  allowedMates?: string[]
+  defaultJoint?: string
+}
+
+export interface JointTemplateDrive {
+  mode: 'velocity' | 'position' | 'spring'
+  target?: number
+  stiffness?: number
+  damping?: number
+  maxForce?: number
+}
+
+export interface JointTemplate {
+  id: string
+  type: 'fixed' | 'revolute' | 'prismatic' | 'spherical' | 'd6'
+  axis?: [number, number, number]
+  limits?: { axis?: 'x' | 'y' | 'z'; lower: number; upper: number }[]
+  drive?: JointTemplateDrive[]
+  friction?: number
+  breakable?: { force: number; torque: number }
+}
+
+export interface MateRule {
+  fromType: string
+  toType: string
+  joint: string
+  alignment?: 'coincident' | 'coaxial' | 'planar'
+}
+
+export interface PowerPortDef {
+  id: string
+  role: 'source' | 'sink' | 'both'
+  voltage?: number
+  maxCurrent?: number
+  connector: string
+  frame: Transform
+}
+
+export interface SignalPortDef {
+  id: string
+  channels: Record<string, 'digital' | 'analog'>
+  frame: Transform
+}
+
+export interface FluidPortDef {
+  id: string
+  medium: 'air' | 'water' | 'fuel' | 'oil'
+  maxFlow?: number
+  frame: Transform
+}
+
+export interface ConveyorPortDef {
+  id: string
+  size: 'small' | 'medium' | 'large'
+  direction: 'in' | 'out' | 'both'
+  frame: Transform
+}
+
+export type ComponentDef = MotorDef | WheelDef | SuspensionDef | BatteryDef | ControllerDef | LightDef
+
+export interface MotorDef {
+  kind: 'Motor'
+  axis: 'x' | 'y' | 'z' | 'custom'
+  drivesSocket?: string
+  nominalPower: watts
+  maxTorque: number
+  maxRPM: number
+  efficiency?: number
+}
+
+export interface WheelDef {
+  kind: 'Wheel'
+  radius: meters
+  width: meters
+  usesRaycast?: boolean
+}
+
+export interface SuspensionDef {
+  kind: 'Suspension'
+  travel: meters
+  stiffness: number
+  damping: number
+}
+
+export interface BatteryDef {
+  kind: 'Battery'
+  capacityWh: number
+  maxDischargeW: watts
+  maxChargeW?: watts
+}
+
+export interface ControllerDef {
+  kind: 'Controller'
+  script?: string
+  inputs?: string[]
+  outputs?: string[]
+}
+
+export interface LightDef {
+  kind: 'Light'
+  lumens: number
+  powerDraw: watts
+}
+
+export interface ParamDef {
+  id: string
+  type: 'float' | 'int' | 'bool' | 'enum' | 'vec3' | 'color'
+  default: any
+  min?: number
+  max?: number
+  step?: number
+  description?: string
+}
+
+export interface MaterialDef {
+  id: string
+  density?: number
+  friction?: number
+  restitution?: number
+  pbr?: any
+}
+
+export interface Meta {
+  author?: string
+  license?: string
+  tags?: string[]
+  cost?: number
+  description?: string
+}
+
+export interface PartDef {
+  id: string
+  version: SemVer
+  name: string
+  category: 'structural' | 'mechanical' | 'electrical' | 'fluid' | 'decor' | 'logic'
+  render?: RenderDef
+  physics?: {
+    dynamic: boolean
+    mass?: kilograms
+    inertiaTensor?: number[]
+    colliders?: ColliderDef[]
+  }
+  sockets: SocketDef[]
+  ports?: {
+    power?: PowerPortDef[]
+    signal?: SignalPortDef[]
+    fluid?: FluidPortDef[]
+    inventory?: ConveyorPortDef[]
+  }
+  components?: ComponentDef[]
+  params?: ParamDef[]
+  metadata?: Meta
+}
+
+export interface PrefabDef {
+  id: string
+  version: SemVer
+  name: string
+  assembly: Assembly
+  params?: ParamDef[]
+}
+
+export interface Catalog {
+  id: string
+  version: SemVer
+  parts: Record<string, PartDef>
+  prefabs?: Record<string, PrefabDef>
+  materials?: Record<string, MaterialDef>
+  jointTemplates?: Record<string, JointTemplate>
+  rules?: MateRule[]
+}
+
+export interface PartInstance {
+  id: UUID
+  partId: string
+  partVersion?: SemVer
+  transform: Transform
+  paramOverrides?: Record<string, any>
+  materialOverrides?: Record<string, any>
+  label?: string
+}
+
+export interface InstanceSocketRef {
+  partInstanceId: UUID
+  socketId: string
+}
+
+export interface JointDriveOverride {
+  mode?: 'velocity' | 'position' | 'spring'
+  target?: number
+  maxForce?: number
+}
+
+export interface JointInstance {
+  id: UUID
+  a: InstanceSocketRef
+  b: InstanceSocketRef
+  template: string
+  anchorAOverride?: Transform
+  anchorBOverride?: Transform
+  limitsOverride?: any
+  driveOverride?: JointDriveOverride
+  articulationGroup?: string
+  label?: string
+}
+
+export interface NetworkConnection {
+  id: UUID
+  kind: 'power' | 'signal' | 'fluid' | 'inventory'
+  from: InstancePortRef
+  to: InstancePortRef
+  properties?: Record<string, any>
+}
+
+export interface InstancePortRef {
+  partInstanceId: UUID
+  portId: string
+}
+
+export interface Group {
+  id: UUID
+  name?: string
+  partIds: UUID[]
+}
+
+export interface Assembly {
+  id: UUID
+  name?: string
+  parts: PartInstance[]
+  joints: JointInstance[]
+  networks?: NetworkConnection[]
+  groups?: Group[]
+  bakePolicy?: 'articulated' | 'compound' | 'grid-merge'
+}
+
+export interface Blueprint {
+  id: UUID
+  name: string
+  version: SemVer
+  root: Assembly
+}
+
+export interface RuntimeState {
+  parts: Record<UUID, PartRuntime>
+  joints: Record<UUID, JointRuntime>
+  networks: Record<UUID, NetworkRuntime>
+  telemetry?: any
+}
+
+export interface PartRuntime {
+  health: number
+  temperature?: number
+  powered?: boolean
+  powerInW?: number
+  powerOutW?: number
+  dynamic?: {
+    velocity: [number, number, number]
+    omega: [number, number, number]
+    asleep: boolean
+  }
+  sensors?: Record<string, number>
+}
+
+export interface JointRuntime {
+  angle?: number
+  position?: number
+  motor?: { enabled: boolean; target?: number; current?: number }
+  broken?: boolean
+}
+
+export interface NetworkRuntime {
+  power?: { voltage: number; current: number }
+  signal?: Record<string, number>
+  fluid?: { flow: number; pressure: number }
+  inventory?: { rate: number; capacity: number }
+}
+
+export interface Inventory {
+  parts: string[]
+  prefabs: string[]
+  quantities?: Record<string, number>
+  favorites?: string[]
+  lastUsed?: string[]
+}
+
+export interface Pack {
+  id: string
+  version: SemVer
+  name: string
+  parts: PartDef[]
+  prefabs?: PrefabDef[]
+  materials?: MaterialDef[]
+  dependencies?: string[]
+  signature?: string
+}


### PR DESCRIPTION
## Summary
- define reusable assembly schema, math helpers, and catalog content for building and vehicle blueprints
- build a react-three-fiber + rapier blueprint renderer with joint visualization and motor control hooks
- add an Assembly Playground page with inspectors, presets for a house and car, and manual drivetrain controls

## Testing
- npm run lint *(fails: biome CLI missing in container without npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68c94c903238832fbb3f6aeca284b9b6