### PR TITLE
Add assembly editor demo with structural and vehicle scenes

### DIFF
--- a/src/app/assembly-editor/page.tsx
+++ b/src/app/assembly-editor/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React from "react";
+
+import AssemblyEditor from "@/components/builder/AssemblyEditor";
+
+export default function AssemblyEditorPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="mx-auto flex max-w-7xl flex-col gap-10 px-6 py-12">
+        <header className="space-y-4 text-center">
+          <h1 className="text-4xl font-bold text-slate-50">
+            Assembly Playground – Structures & Vehicles
+          </h1>
+          <p className="mx-auto max-w-3xl text-base text-slate-300">
+            Experiment with part-based construction, constraint-driven joints, and
+            articulated physics. The demo ships with a hinge-driven house scene and a
+            drivable rover that uses Rapier motors for its wheel articulations.
+          </p>
+        </header>
+        <AssemblyEditor />
+        <footer className="text-center text-sm text-slate-500">
+          <p>
+            Controls: <strong>Edit</strong> mode exposes a transform gizmo, while
+            <strong> Simulate</strong> mode activates Rapier physics, keyboard drive
+            (WASD / arrow keys), and live joint targets.
+          </p>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,12 @@ export default function Home() {
           🎲 THREE.js Demo
         </a>
         <a
+          href="/assembly-editor"
+          className="rounded-lg bg-blue-500/80 hover:bg-blue-600 text-white font-medium text-center py-3 px-4 transition-colors"
+        >
+          🛠️ Assembly Playground
+        </a>
+        <a
           href="/grass-v2"
           className="rounded-lg bg-gray-800 hover:bg-gray-700 text-white font-medium text-center py-3 px-4 transition-colors"
         >

--- a/src/components/builder/AssemblyCanvas.tsx
+++ b/src/components/builder/AssemblyCanvas.tsx
@@ -1,0 +1,818 @@
+"use client";
+
+import React, {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Canvas, ThreeEvent, useFrame } from "@react-three/fiber";
+import {
+  Grid,
+  OrbitControls,
+  TransformControls,
+} from "@react-three/drei";
+import type { OrbitControls as OrbitControlsImpl } from "three-stdlib";
+import type { TransformControls as TransformControlsImpl } from "three/examples/jsm/controls/TransformControls";
+import {
+  CuboidCollider,
+  CylinderCollider,
+  Physics,
+  RigidBody,
+  useFixedJoint,
+  useRevoluteJoint,
+  type RapierImpulseJoint,
+  type RapierRigidBody,
+} from "@react-three/rapier";
+import { Color, Group, Quaternion, Vector3 } from "three";
+
+import type {
+  Blueprint,
+  Catalog,
+  ColliderDef,
+  JointInstance,
+  JointTemplate,
+  PartDef,
+  PartInstance,
+  Transform,
+} from "@/lib/builder/model";
+import {
+  quaternionToArray,
+  quaternionToEuler,
+  vectorToArray,
+} from "@/lib/builder/math";
+import { findPartInstance } from "@/lib/builder/utils";
+
+const identityQuat: Transform["rotationQuat"] = [0, 0, 0, 1];
+const defaultStructuralColor = new Color("#9ca3af");
+const defaultMechanicalColor = new Color("#1f2937");
+
+interface AssemblyCanvasProps {
+  blueprint: Blueprint;
+  catalog: Catalog;
+  mode: "edit" | "simulate";
+  selectedPartId?: string | null;
+  onSelectPart?: (id: string | null) => void;
+  onTransformChange?: (id: string, transform: Transform) => void;
+  transformMode: "translate" | "rotate";
+  jointTargets?: Record<string, number | undefined>;
+}
+
+interface RegisteredBody {
+  id: string;
+  api: RapierRigidBody;
+  part: PartInstance;
+  partDef: PartDef;
+  object: Group | null;
+}
+
+interface RegisteredJoint {
+  id: string;
+  joint: RapierImpulseJoint;
+  instance: JointInstance;
+  template: JointTemplate;
+}
+
+interface AssemblyRuntimeContextValue {
+  bodies: Map<string, RegisteredBody>;
+  joints: Map<string, RegisteredJoint>;
+  registerBody: (entry: RegisteredBody) => void;
+  unregisterBody: (id: string) => void;
+  registerJoint: (entry: RegisteredJoint) => void;
+  unregisterJoint: (id: string) => void;
+  version: number;
+}
+
+const AssemblyRuntimeContext = React.createContext<AssemblyRuntimeContextValue | null>(
+  null,
+);
+
+function useAssemblyRuntime() {
+  const ctx = React.useContext(AssemblyRuntimeContext);
+  if (!ctx) {
+    throw new Error("Assembly runtime context is missing");
+  }
+  return ctx;
+}
+
+function highlightColor(hex: string | undefined, selected: boolean): string {
+  const base = new Color(hex ?? defaultStructuralColor);
+  if (selected) {
+    const highlight = base.clone().lerp(new Color("#f97316"), 0.4);
+    return `#${highlight.getHexString()}`;
+  }
+  return `#${base.getHexString()}`;
+}
+
+function colliderRotationEuler(collider: ColliderDef): [number, number, number] {
+  const rotation = collider.offset?.rotationQuat ?? identityQuat;
+  return quaternionToEuler(rotation);
+}
+
+function ColliderPrimitive({ collider }: { collider: ColliderDef }) {
+  const position = collider.offset?.position ?? [0, 0, 0];
+  const rotation = colliderRotationEuler(collider);
+  const friction = collider.material?.friction;
+  const restitution = collider.material?.restitution;
+
+  switch (collider.shape) {
+    case "box":
+      return (
+        <CuboidCollider
+          args={collider.params as [number, number, number]}
+          position={position}
+          rotation={rotation}
+          friction={friction}
+          restitution={restitution}
+        />
+      );
+    case "cylinder": {
+      const [radius, halfHeight] = collider.params;
+      return (
+        <CylinderCollider
+          args={[halfHeight ?? collider.params[1], radius ?? collider.params[0]]}
+          position={position}
+          rotation={rotation}
+          friction={friction}
+          restitution={restitution}
+        />
+      );
+    }
+    default:
+      return null;
+  }
+}
+
+interface PartRigidBodyProps {
+  part: PartInstance;
+  partDef: PartDef;
+  mode: "edit" | "simulate";
+  selected: boolean;
+  onSelect?: (id: string) => void;
+}
+
+function PartRigidBody({
+  part,
+  partDef,
+  mode,
+  selected,
+  onSelect,
+}: PartRigidBodyProps) {
+  const bodyRef = useRef<RapierRigidBody>(null);
+  const groupRef = useRef<Group>(null);
+  const runtime = useAssemblyRuntime();
+  const isDynamic = partDef.physics?.dynamic ?? false;
+  const type = mode === "edit" ? "kinematicPosition" : isDynamic ? "dynamic" : "fixed";
+  const rotationEuler = quaternionToEuler(part.transform.rotationQuat);
+  const transformKey = useMemo(
+    () =>
+      `${part.transform.position.join(",")}|${part.transform.rotationQuat.join(",")}`,
+    [part.transform.position, part.transform.rotationQuat],
+  );
+
+  useEffect(() => {
+    const body = bodyRef.current;
+    const object = groupRef.current;
+    if (!body || !object) return;
+    runtime.registerBody({
+      id: part.id,
+      api: body,
+      part,
+      partDef,
+      object,
+    });
+    return () => runtime.unregisterBody(part.id);
+  }, [part, partDef, runtime]);
+
+  useEffect(() => {
+    const body = bodyRef.current;
+    if (!body) return;
+    const [x, y, z] = part.transform.position;
+    const [qx, qy, qz, qw] = part.transform.rotationQuat;
+    body.setTranslation({ x, y, z }, true);
+    body.setRotation({ x: qx, y: qy, z: qz, w: qw }, true);
+    if (mode === "simulate" && isDynamic) {
+      body.setLinvel({ x: 0, y: 0, z: 0 }, true);
+      body.setAngvel({ x: 0, y: 0, z: 0 }, true);
+    }
+  }, [transformKey, mode, isDynamic]);
+
+  const handlePointerDown = useCallback(
+    (event: ThreeEvent<MouseEvent>) => {
+      event.stopPropagation();
+      onSelect?.(part.id);
+    },
+    [onSelect, part.id],
+  );
+
+  const colliders = partDef.physics?.colliders ?? [];
+  const colliderElements = colliders.map((collider, index) => (
+    <ColliderPrimitive key={`${part.id}-collider-${index}`} collider={collider} />
+  ));
+
+  return (
+    <RigidBody
+      ref={bodyRef}
+      type={type}
+      colliders={false}
+      position={part.transform.position}
+      rotation={rotationEuler}
+      mass={partDef.physics?.mass}
+      enabledTranslations={mode === "edit" ? [true, true, true] : undefined}
+      enabledRotations={mode === "edit" ? [true, true, true] : undefined}
+    >
+      <group ref={groupRef} userData={{ partInstanceId: part.id }}>
+        <PartVisual
+          part={part}
+          partDef={partDef}
+          selected={selected}
+          onPointerDown={handlePointerDown}
+        />
+      </group>
+      {colliderElements}
+    </RigidBody>
+  );
+}
+
+interface PartVisualProps {
+  part: PartInstance;
+  partDef: PartDef;
+  selected: boolean;
+  onPointerDown: (event: ThreeEvent<MouseEvent>) => void;
+}
+
+function PartVisual({
+  part,
+  partDef,
+  selected,
+  onPointerDown,
+}: PartVisualProps) {
+  const collider = partDef.physics?.colliders[0];
+  const color = highlightColor(
+    partDef.metadata?.color ??
+      (partDef.category === "mechanical"
+        ? `#${defaultMechanicalColor.getHexString()}`
+        : `#${defaultStructuralColor.getHexString()}`),
+    selected,
+  );
+
+  if (!collider) {
+    return null;
+  }
+
+  switch (collider.shape) {
+    case "box": {
+      const [hx, hy, hz] = collider.params;
+      return (
+        <mesh
+          name={part.label ?? part.id}
+          castShadow
+          receiveShadow
+          onPointerDown={onPointerDown}
+        >
+          <boxGeometry args={[hx * 2, hy * 2, hz * 2]} />
+          <meshStandardMaterial color={color} roughness={0.6} metalness={0.1} />
+        </mesh>
+      );
+    }
+    case "cylinder": {
+      const [radius, halfHeight] = collider.params;
+      return (
+        <mesh
+          name={part.label ?? part.id}
+          castShadow
+          receiveShadow
+          rotation={[0, 0, Math.PI / 2]}
+          onPointerDown={onPointerDown}
+        >
+          <cylinderGeometry args={[radius, radius, (halfHeight ?? 0.12) * 2, 24]} />
+          <meshStandardMaterial color={color} roughness={0.5} metalness={0.2} />
+        </mesh>
+      );
+    }
+    default:
+      return null;
+  }
+}
+
+interface AssemblyBodiesProps {
+  blueprint: Blueprint;
+  catalog: Catalog;
+  mode: "edit" | "simulate";
+  selectedPartId?: string | null;
+  onSelectPart?: (id: string) => void;
+}
+
+function AssemblyBodies({
+  blueprint,
+  catalog,
+  mode,
+  selectedPartId,
+  onSelectPart,
+}: AssemblyBodiesProps) {
+  return (
+    <Fragment>
+      {blueprint.root.parts.map((part) => {
+        const partDef = catalog.parts[part.partId];
+        if (!partDef) return null;
+        return (
+          <PartRigidBody
+            key={`${part.id}-${mode}`}
+            part={part}
+            partDef={partDef}
+            mode={mode}
+            selected={selectedPartId === part.id}
+            onSelect={onSelectPart}
+          />
+        );
+      })}
+    </Fragment>
+  );
+}
+
+function socketTransform(
+  part: PartInstance,
+  partDef: PartDef,
+  socketId: string,
+): Transform {
+  const socket = partDef.sockets.find((s) => s.id === socketId);
+  if (!socket) {
+    return {
+      position: [0, 0, 0],
+      rotationQuat: identityQuat,
+    };
+  }
+  return socket.frame;
+}
+
+interface JointRendererProps {
+  joint: JointInstance;
+  template: JointTemplate;
+  catalog: Catalog;
+  blueprint: Blueprint;
+  jointTarget?: number;
+}
+
+function JointRenderer({
+  joint,
+  template,
+  catalog,
+  blueprint,
+  jointTarget,
+}: JointRendererProps) {
+  const runtime = useAssemblyRuntime();
+  const partA = findPartInstance(blueprint, joint.a.partInstanceId);
+  const partB = findPartInstance(blueprint, joint.b.partInstanceId);
+  if (!partA || !partB) return null;
+  const partDefA = catalog.parts[partA.partId];
+  const partDefB = catalog.parts[partB.partId];
+  if (!partDefA || !partDefB) return null;
+
+  const bodyA = runtime.bodies.get(partA.id)?.api ?? null;
+  const bodyB = runtime.bodies.get(partB.id)?.api ?? null;
+
+  if (!bodyA || !bodyB) {
+    return null;
+  }
+
+  const socketA = socketTransform(partA, partDefA, joint.a.socketId);
+  const socketB = socketTransform(partB, partDefB, joint.b.socketId);
+
+  if (template.type === "fixed") {
+    return (
+      <FixedJointComponent
+        joint={joint}
+        template={template}
+        bodyA={bodyA}
+        bodyB={bodyB}
+        socketA={socketA}
+        socketB={socketB}
+      />
+    );
+  }
+
+  if (template.type === "revolute") {
+    return (
+      <RevoluteJointComponent
+        joint={joint}
+        template={template}
+        bodyA={bodyA}
+        bodyB={bodyB}
+        socketA={socketA}
+        socketB={socketB}
+        target={jointTarget}
+      />
+    );
+  }
+
+  return null;
+}
+
+interface RevoluteJointComponentProps {
+  joint: JointInstance;
+  template: JointTemplate;
+  bodyA: RapierRigidBody;
+  bodyB: RapierRigidBody;
+  socketA: Transform;
+  socketB: Transform;
+  target?: number;
+}
+
+function RevoluteJointComponent({
+  joint,
+  template,
+  bodyA,
+  bodyB,
+  socketA,
+  socketB,
+  target,
+}: RevoluteJointComponentProps) {
+  const runtime = useAssemblyRuntime();
+  const localAnchorA = socketA.position;
+  const localAnchorB = socketB.position;
+  const axis = template.axis ?? [0, 1, 0];
+  const limits = joint.limitsOverride ?? template.limits;
+
+  const [jointRef, rapierJoint] = useRevoluteJoint(bodyA, bodyB, {
+    localAnchorA,
+    localAnchorB,
+    axis,
+  });
+
+  useEffect(() => {
+    if (rapierJoint && limits) {
+      rapierJoint.setLimits(limits.lower, limits.upper);
+    }
+  }, [rapierJoint, limits?.lower, limits?.upper]);
+
+  useEffect(() => {
+    if (!rapierJoint) return;
+    runtime.registerJoint({
+      id: joint.id,
+      joint: rapierJoint,
+      instance: joint,
+      template,
+    });
+    return () => runtime.unregisterJoint(joint.id);
+  }, [rapierJoint, runtime, joint, template]);
+
+  useEffect(() => {
+    if (!rapierJoint || template.drive?.mode !== "position") return;
+    const stiffness = joint.driveOverride?.stiffness ?? template.drive.stiffness ?? 30;
+    const damping = joint.driveOverride?.damping ?? template.drive.damping ?? 4;
+    const maxForce = joint.driveOverride?.maxForce ?? template.drive.maxForce ?? 200;
+    const targetValue = target ?? joint.driveOverride?.target ?? template.drive.target ?? 0;
+    rapierJoint.configureMotorPosition(targetValue, stiffness, damping);
+  }, [rapierJoint, template.drive, joint.driveOverride, target]);
+
+  useEffect(() => {
+    if (!rapierJoint || template.drive?.mode !== "velocity") return;
+    const maxForce = joint.driveOverride?.maxForce ?? template.drive.maxForce ?? 200;
+    const targetValue = joint.driveOverride?.target ?? template.drive.target ?? 0;
+    rapierJoint.configureMotorVelocity(targetValue, maxForce);
+  }, [rapierJoint, template.drive, joint.driveOverride]);
+
+  return <primitive object={jointRef} />;
+}
+
+interface FixedJointComponentProps {
+  joint: JointInstance;
+  template: JointTemplate;
+  bodyA: RapierRigidBody;
+  bodyB: RapierRigidBody;
+  socketA: Transform;
+  socketB: Transform;
+}
+
+function FixedJointComponent({
+  joint,
+  template,
+  bodyA,
+  bodyB,
+  socketA,
+  socketB,
+}: FixedJointComponentProps) {
+  const runtime = useAssemblyRuntime();
+  const [jointRef, rapierJoint] = useFixedJoint(bodyA, bodyB, {
+    localAnchorA: socketA.position,
+    localAnchorB: socketB.position,
+  });
+
+  useEffect(() => {
+    if (!rapierJoint) return;
+    runtime.registerJoint({
+      id: joint.id,
+      joint: rapierJoint,
+      instance: joint,
+      template,
+    });
+    return () => runtime.unregisterJoint(joint.id);
+  }, [rapierJoint, runtime, joint, template]);
+
+  return <primitive object={jointRef} />;
+}
+
+function ArticulationControllers({
+  blueprint,
+  mode,
+}: {
+  blueprint: Blueprint;
+  mode: "edit" | "simulate";
+}) {
+  const runtime = useAssemblyRuntime();
+  const inputsRef = useRef({ forward: 0, turn: 0 });
+  const hasVehicle = blueprint.root.metadata?.kind === "vehicle";
+
+  useEffect(() => {
+    if (!hasVehicle) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.code === "KeyW" || event.code === "ArrowUp") {
+        inputsRef.current.forward = 1;
+      }
+      if (event.code === "KeyS" || event.code === "ArrowDown") {
+        inputsRef.current.forward = -1;
+      }
+      if (event.code === "KeyA" || event.code === "ArrowLeft") {
+        inputsRef.current.turn = -1;
+      }
+      if (event.code === "KeyD" || event.code === "ArrowRight") {
+        inputsRef.current.turn = 1;
+      }
+    };
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.code === "KeyW" || event.code === "ArrowUp") {
+        if (inputsRef.current.forward === 1) inputsRef.current.forward = 0;
+      }
+      if (event.code === "KeyS" || event.code === "ArrowDown") {
+        if (inputsRef.current.forward === -1) inputsRef.current.forward = 0;
+      }
+      if (event.code === "KeyA" || event.code === "ArrowLeft") {
+        if (inputsRef.current.turn === -1) inputsRef.current.turn = 0;
+      }
+      if (event.code === "KeyD" || event.code === "ArrowRight") {
+        if (inputsRef.current.turn === 1) inputsRef.current.turn = 0;
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, [hasVehicle]);
+
+  useFrame(() => {
+    if (!hasVehicle || mode !== "simulate") return;
+    const joints = Array.from(runtime.joints.values()).filter((entry) =>
+      entry.instance.tags?.includes("drive"),
+    );
+    if (joints.length === 0) return;
+
+    const { forward, turn } = inputsRef.current;
+    const baseSpeed = 16;
+    const turnStrength = 6;
+
+    joints.forEach((entry) => {
+      if (!("configureMotorVelocity" in entry.joint)) return;
+      const isLeft = entry.instance.tags?.includes("left");
+      const turnContribution = turn * (isLeft ? -turnStrength : turnStrength);
+      const targetVelocity = forward * baseSpeed + turnContribution;
+      const maxForce = entry.template.drive?.maxForce ?? 450;
+      entry.joint.configureMotorVelocity(targetVelocity, maxForce);
+    });
+  });
+
+  return null;
+}
+
+interface EditorTransformControlsProps {
+  mode: "edit" | "simulate";
+  transformMode: "translate" | "rotate";
+  selectedPartId?: string | null;
+  onTransformChange?: (id: string, transform: Transform) => void;
+  orbitRef: React.RefObject<OrbitControlsImpl>;
+}
+
+function EditorTransformControls({
+  mode,
+  transformMode,
+  selectedPartId,
+  onTransformChange,
+  orbitRef,
+}: EditorTransformControlsProps) {
+  const runtime = useAssemblyRuntime();
+  const transformRef = useRef<TransformControlsImpl>(null);
+
+  const selectedObject = useMemo(() => {
+    if (!selectedPartId) return null;
+    return runtime.bodies.get(selectedPartId)?.object ?? null;
+  }, [runtime, selectedPartId, runtime.version]);
+
+  useEffect(() => {
+    const controls = transformRef.current;
+    if (!controls) return;
+    if (mode === "edit" && selectedObject) {
+      controls.attach(selectedObject);
+    } else {
+      controls.detach();
+    }
+  }, [mode, selectedObject]);
+
+  useEffect(() => {
+    const controls = transformRef.current;
+    const orbit = orbitRef.current;
+    if (!controls || !orbit) return;
+    const callback = (event: { value: boolean }) => {
+      orbit.enabled = !event.value;
+    };
+    controls.addEventListener("dragging-changed", callback);
+    return () => controls.removeEventListener("dragging-changed", callback);
+  }, [orbitRef]);
+
+  const handleObjectChange = useCallback(() => {
+    const controls = transformRef.current;
+    if (!controls || !controls.object || !selectedPartId || !onTransformChange)
+      return;
+    const object = controls.object as Group;
+    onTransformChange(selectedPartId, {
+      position: vectorToArray(object.position as Vector3),
+      rotationQuat: quaternionToArray(object.quaternion as Quaternion),
+    });
+  }, [onTransformChange, selectedPartId]);
+
+  return (
+    <TransformControls
+      ref={transformRef}
+      enabled={mode === "edit" && !!selectedObject}
+      mode={transformMode}
+      onObjectChange={handleObjectChange}
+    />
+  );
+}
+
+function AssemblyRuntimeProvider({ children }: { children: React.ReactNode }) {
+  const bodiesRef = useRef(new Map<string, RegisteredBody>());
+  const jointsRef = useRef(new Map<string, RegisteredJoint>());
+  const [version, setVersion] = useState(0);
+
+  const bumpVersion = useCallback(() => {
+    setVersion((value) => value + 1);
+  }, []);
+
+  const registerBody = useCallback(
+    (entry: RegisteredBody) => {
+      bodiesRef.current.set(entry.id, entry);
+      bumpVersion();
+    },
+    [bumpVersion],
+  );
+
+  const unregisterBody = useCallback(
+    (id: string) => {
+      if (bodiesRef.current.delete(id)) {
+        bumpVersion();
+      }
+    },
+    [bumpVersion],
+  );
+
+  const registerJoint = useCallback(
+    (entry: RegisteredJoint) => {
+      jointsRef.current.set(entry.id, entry);
+      bumpVersion();
+    },
+    [bumpVersion],
+  );
+
+  const unregisterJoint = useCallback(
+    (id: string) => {
+      if (jointsRef.current.delete(id)) {
+        bumpVersion();
+      }
+    },
+    [bumpVersion],
+  );
+
+  const contextValue = useMemo<AssemblyRuntimeContextValue>(
+    () => ({
+      bodies: bodiesRef.current,
+      joints: jointsRef.current,
+      registerBody,
+      unregisterBody,
+      registerJoint,
+      unregisterJoint,
+      version,
+    }),
+    [registerBody, registerJoint, unregisterBody, unregisterJoint, version],
+  );
+
+  return (
+    <AssemblyRuntimeContext.Provider value={contextValue}>
+      {children}
+    </AssemblyRuntimeContext.Provider>
+  );
+}
+
+function useSelectedObject(
+  runtime: AssemblyRuntimeContextValue,
+  selectedPartId?: string | null,
+): Group | null {
+  return useMemo(() => {
+    if (!selectedPartId) return null;
+    return runtime.bodies.get(selectedPartId)?.object ?? null;
+  }, [runtime, selectedPartId, runtime.version]);
+}
+
+export function AssemblyCanvas({
+  blueprint,
+  catalog,
+  mode,
+  selectedPartId,
+  onSelectPart,
+  onTransformChange,
+  transformMode,
+  jointTargets,
+}: AssemblyCanvasProps) {
+  const physicsKey = `${mode}-${blueprint.id}`;
+  const orbitRef = useRef<OrbitControlsImpl>(null);
+  const handlePartSelect = useCallback(
+    (id: string) => {
+      onSelectPart?.(id);
+    },
+    [onSelectPart],
+  );
+
+  return (
+    <div className="relative w-full h-full bg-gray-900 rounded-lg overflow-hidden">
+      <Canvas
+        shadows
+        camera={{ position: [10, 8, 10], fov: 45 }}
+        dpr={[1, 2]}
+        onPointerMissed={() => onSelectPart?.(null)}
+      >
+        <color attach="background" args={["#0f172a"]} />
+        <ambientLight intensity={0.5} />
+        <directionalLight
+          position={[8, 12, 6]}
+          intensity={1.2}
+          castShadow
+          shadow-mapSize={[1024, 1024]}
+        />
+        <AssemblyRuntimeProvider>
+          <Physics
+            key={physicsKey}
+            gravity={[0, mode === "simulate" ? -9.81 : 0, 0]}
+            colliders={false}
+          >
+            <AssemblyBodies
+              blueprint={blueprint}
+              catalog={catalog}
+              mode={mode}
+              selectedPartId={selectedPartId}
+              onSelectPart={handlePartSelect}
+            />
+            {blueprint.root.joints.map((joint) => {
+              const template = catalog.jointTemplates?.[joint.template];
+              if (!template) return null;
+              return (
+                <JointRenderer
+                  key={joint.id}
+                  joint={joint}
+                  template={template}
+                  blueprint={blueprint}
+                  catalog={catalog}
+                  jointTarget={jointTargets?.[joint.id]}
+                />
+              );
+            })}
+          </Physics>
+          <ArticulationControllers blueprint={blueprint} mode={mode} />
+          <EditorTransformControls
+            mode={mode}
+            transformMode={transformMode}
+            selectedPartId={selectedPartId}
+            onTransformChange={onTransformChange}
+            orbitRef={orbitRef}
+          />
+        </AssemblyRuntimeProvider>
+        <Grid
+          args={[20, 20]}
+          cellSize={1}
+          cellThickness={0.5}
+          sectionSize={5}
+          sectionThickness={1}
+          sectionColor="gray"
+          cellColor="#2c3a56"
+          fadeDistance={40}
+          fadeStrength={1}
+          position={[0, 0.01, 0]}
+        />
+        <OrbitControls ref={orbitRef} makeDefault maxPolarAngle={Math.PI / 2} />
+      </Canvas>
+    </div>
+  );
+}
+
+export default AssemblyCanvas;

--- a/src/components/builder/AssemblyEditor.tsx
+++ b/src/components/builder/AssemblyEditor.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+
+import { AssemblyCanvas } from "./AssemblyCanvas";
+import {
+  builderCatalog,
+  editorExamples,
+  getExampleBlueprint,
+  type ExampleId,
+} from "@/lib/builder/examples";
+import type { Blueprint, PartInstance, Transform } from "@/lib/builder/model";
+import {
+  DEG2RAD,
+  RAD2DEG,
+  eulerToQuaternion,
+  quaternionToEuler,
+} from "@/lib/builder/math";
+import {
+  findJointByTag,
+  partLabel,
+  updatePartTransform,
+} from "@/lib/builder/utils";
+
+function formatNumber(value: number, fractionDigits = 2) {
+  return Number.parseFloat(value.toFixed(fractionDigits));
+}
+
+function transformWithUpdate(
+  part: PartInstance,
+  updater: (transform: Transform) => Transform,
+  blueprint: Blueprint,
+  setBlueprint: (next: Blueprint) => void,
+) {
+  const updated = updater(part.transform);
+  setBlueprint(updatePartTransform(blueprint, part.id, updated));
+}
+
+export function AssemblyEditor() {
+  const [exampleId, setExampleId] = useState<ExampleId>("house");
+  const [blueprint, setBlueprint] = useState<Blueprint>(() =>
+    getExampleBlueprint("house"),
+  );
+  const [mode, setMode] = useState<"edit" | "simulate">("edit");
+  const [transformMode, setTransformMode] =
+    useState<"translate" | "rotate">("translate");
+  const [selectedPartId, setSelectedPartId] = useState<string | null>(null);
+  const [doorAngleDeg, setDoorAngleDeg] = useState<number>(0);
+  const [jointTargets, setJointTargets] = useState<Record<string, number>>({});
+
+  const catalog = builderCatalog;
+
+  const selectedPart = useMemo(
+    () => blueprint.root.parts.find((part) => part.id === selectedPartId),
+    [blueprint, selectedPartId],
+  );
+
+  const selectedPartDef = useMemo(() => {
+    if (!selectedPart) return undefined;
+    return catalog.parts[selectedPart.partId];
+  }, [catalog.parts, selectedPart]);
+
+  const doorJoint = useMemo(() => findJointByTag(blueprint, "door"), [blueprint]);
+
+  const handleSelectExample = (id: ExampleId) => {
+    const next = getExampleBlueprint(id);
+    setExampleId(id);
+    setBlueprint(next);
+    setMode("edit");
+    setTransformMode("translate");
+    setSelectedPartId(null);
+    setDoorAngleDeg(0);
+    const door = findJointByTag(next, "door");
+    setJointTargets(door ? { [door.id]: 0 } : {});
+  };
+
+  const handleSelectPart = (id: string | null) => {
+    setSelectedPartId((current) => (current === id ? null : id));
+  };
+
+  const handleTransformChange = (partId: string, transform: Transform) => {
+    setBlueprint((current) => updatePartTransform(current, partId, transform));
+  };
+
+  const handlePositionChange = (axis: 0 | 1 | 2, value: number) => {
+    if (!selectedPart) return;
+    transformWithUpdate(
+      selectedPart,
+      (transform) => {
+        const nextPosition: Transform["position"] = [...transform.position];
+        nextPosition[axis] = value;
+        return {
+          position: nextPosition,
+          rotationQuat: [...transform.rotationQuat],
+        };
+      },
+      blueprint,
+      setBlueprint,
+    );
+  };
+
+  const handleRotationChange = (axis: 0 | 1 | 2, valueDeg: number) => {
+    if (!selectedPart) return;
+    transformWithUpdate(
+      selectedPart,
+      (transform) => {
+        const euler = quaternionToEuler(transform.rotationQuat);
+        const nextEuler: [number, number, number] = [...euler];
+        nextEuler[axis] = valueDeg * DEG2RAD;
+        return {
+          position: [...transform.position],
+          rotationQuat: eulerToQuaternion(nextEuler),
+        };
+      },
+      blueprint,
+      setBlueprint,
+    );
+  };
+
+  const handleDoorAngleChange = (value: number) => {
+    setDoorAngleDeg(value);
+    if (!doorJoint) return;
+    setJointTargets((previous) => ({
+      ...previous,
+      [doorJoint.id]: value * DEG2RAD,
+    }));
+  };
+
+  const activeJointTargets = useMemo(() => {
+    if (!doorJoint) return jointTargets;
+    return {
+      ...jointTargets,
+      [doorJoint.id]: doorAngleDeg * DEG2RAD,
+    };
+  }, [doorJoint, jointTargets, doorAngleDeg]);
+
+  const partItems = blueprint.root.parts.map((part) => {
+    const def = catalog.parts[part.partId];
+    return {
+      part,
+      def,
+      label: partLabel(part, def?.name),
+    };
+  });
+
+  return (
+    <div className="flex flex-col gap-6 lg:flex-row">
+      <aside className="w-full lg:w-80 flex-shrink-0 space-y-6 rounded-xl bg-slate-900/80 p-6 text-slate-100 shadow-lg">
+        <section>
+          <h2 className="mb-3 text-lg font-semibold text-slate-50">Blueprint</h2>
+          <div className="grid grid-cols-1 gap-2">
+            {Object.values(editorExamples).map((example) => (
+              <button
+                key={example.id}
+                onClick={() => handleSelectExample(example.id)}
+                className={`rounded-lg border px-3 py-2 text-left transition-colors ${exampleId === example.id ? "border-blue-400 bg-blue-500/20" : "border-slate-700 hover:border-blue-400/60"}`}
+              >
+                <div className="text-sm font-medium text-slate-100">
+                  {example.label}
+                </div>
+                <div className="text-xs text-slate-400">
+                  {example.id === "house"
+                    ? "Static structure with articulated door"
+                    : "Four-wheel rover with drive motors"}
+                </div>
+              </button>
+            ))}
+            <button
+              onClick={() => handleSelectExample(exampleId)}
+              className="rounded-lg border border-slate-700 px-3 py-2 text-left text-sm text-slate-200 transition hover:border-blue-400/60"
+            >
+              Reset Current Blueprint
+            </button>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-lg font-semibold text-slate-50">Mode</h2>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setMode("edit")}
+              className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition ${mode === "edit" ? "bg-blue-500 text-white" : "bg-slate-800 text-slate-300 hover:bg-slate-700"}`}
+            >
+              Edit
+            </button>
+            <button
+              onClick={() => setMode("simulate")}
+              className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition ${mode === "simulate" ? "bg-emerald-500 text-white" : "bg-slate-800 text-slate-300 hover:bg-slate-700"}`}
+            >
+              Simulate
+            </button>
+          </div>
+          <div className="mt-4 flex gap-2">
+            <button
+              onClick={() => setTransformMode("translate")}
+              className={`flex-1 rounded-md px-2 py-1 text-xs font-medium transition ${transformMode === "translate" ? "bg-blue-400/30 text-blue-100" : "bg-slate-800 text-slate-300 hover:bg-slate-700"}`}
+            >
+              Move
+            </button>
+            <button
+              onClick={() => setTransformMode("rotate")}
+              className={`flex-1 rounded-md px-2 py-1 text-xs font-medium transition ${transformMode === "rotate" ? "bg-blue-400/30 text-blue-100" : "bg-slate-800 text-slate-300 hover:bg-slate-700"}`}
+            >
+              Rotate
+            </button>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-lg font-semibold text-slate-50">Parts</h2>
+          <div className="space-y-2 max-h-64 overflow-y-auto pr-1">
+            {partItems.map(({ part, def, label }) => (
+              <button
+                key={part.id}
+                onClick={() => handleSelectPart(part.id)}
+                className={`w-full rounded-md border px-3 py-2 text-left text-sm transition ${selectedPartId === part.id ? "border-blue-400 bg-blue-500/20" : "border-slate-700 bg-slate-800 hover:border-blue-400/60"}`}
+              >
+                <div className="font-medium text-slate-100">{label}</div>
+                <div className="text-xs text-slate-400">
+                  {def?.category ?? "Unknown"} · {def?.physics?.dynamic ? "Dynamic" : "Static"}
+                </div>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        {selectedPart && selectedPartDef && (
+          <section className="space-y-3">
+            <h3 className="text-lg font-semibold text-slate-50">Transform</h3>
+            <div className="space-y-2 text-xs text-slate-200">
+              <div className="grid grid-cols-4 items-center gap-2">
+                <span className="col-span-1 text-slate-400">Pos X</span>
+                <input
+                  type="number"
+                  className="col-span-3 rounded bg-slate-800 px-2 py-1"
+                  step={0.1}
+                  value={formatNumber(selectedPart.transform.position[0])}
+                  onChange={(event) =>
+                    handlePositionChange(0, Number.parseFloat(event.target.value))
+                  }
+                />
+                <span className="text-slate-400">Pos Y</span>
+                <input
+                  type="number"
+                  className="col-span-3 rounded bg-slate-800 px-2 py-1"
+                  step={0.1}
+                  value={formatNumber(selectedPart.transform.position[1])}
+                  onChange={(event) =>
+                    handlePositionChange(1, Number.parseFloat(event.target.value))
+                  }
+                />
+                <span className="text-slate-400">Pos Z</span>
+                <input
+                  type="number"
+                  className="col-span-3 rounded bg-slate-800 px-2 py-1"
+                  step={0.1}
+                  value={formatNumber(selectedPart.transform.position[2])}
+                  onChange={(event) =>
+                    handlePositionChange(2, Number.parseFloat(event.target.value))
+                  }
+                />
+              </div>
+              {(() => {
+                const euler = quaternionToEuler(selectedPart.transform.rotationQuat).map((value) => value * RAD2DEG) as [number, number, number];
+                return (
+                  <div className="grid grid-cols-4 items-center gap-2">
+                    <span className="text-slate-400">Rot X°</span>
+                    <input
+                      type="number"
+                      className="col-span-3 rounded bg-slate-800 px-2 py-1"
+                      step={1}
+                      value={formatNumber(euler[0], 1)}
+                      onChange={(event) =>
+                        handleRotationChange(0, Number.parseFloat(event.target.value))
+                      }
+                    />
+                    <span className="text-slate-400">Rot Y°</span>
+                    <input
+                      type="number"
+                      className="col-span-3 rounded bg-slate-800 px-2 py-1"
+                      step={1}
+                      value={formatNumber(euler[1], 1)}
+                      onChange={(event) =>
+                        handleRotationChange(1, Number.parseFloat(event.target.value))
+                      }
+                    />
+                    <span className="text-slate-400">Rot Z°</span>
+                    <input
+                      type="number"
+                      className="col-span-3 rounded bg-slate-800 px-2 py-1"
+                      step={1}
+                      value={formatNumber(euler[2], 1)}
+                      onChange={(event) =>
+                        handleRotationChange(2, Number.parseFloat(event.target.value))
+                      }
+                    />
+                  </div>
+                );
+              })()}
+            </div>
+          </section>
+        )}
+
+        {doorJoint && (
+          <section className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-slate-50">Door Angle</h3>
+              <span className="text-xs text-slate-400">{formatNumber(doorAngleDeg, 1)}°</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={90}
+              step={1}
+              value={doorAngleDeg}
+              onChange={(event) => handleDoorAngleChange(Number.parseFloat(event.target.value))}
+              className="w-full"
+            />
+            <p className="text-xs text-slate-400">
+              Use the slider to set a target angle for the hinged door while in
+              simulation mode. The joint motor will hold the selected position.
+            </p>
+          </section>
+        )}
+
+        <section className="space-y-2 rounded-md bg-slate-800/60 p-3 text-xs text-slate-300">
+          <h3 className="text-sm font-semibold text-slate-200">Tips</h3>
+          <ul className="space-y-1 list-disc pl-4">
+            <li>Select parts from the list or click them in the viewport.</li>
+            <li>Use the gizmo to move or rotate parts while in Edit mode.</li>
+            <li>In Simulate mode, drive the rover with WASD or arrow keys.</li>
+            <li>Door motors accept angle targets even while editing.</li>
+          </ul>
+        </section>
+      </aside>
+
+      <section className="flex-1 min-h-[600px]">
+        <AssemblyCanvas
+          blueprint={blueprint}
+          catalog={catalog}
+          mode={mode}
+          selectedPartId={selectedPartId}
+          onSelectPart={handleSelectPart}
+          onTransformChange={handleTransformChange}
+          transformMode={transformMode}
+          jointTargets={activeJointTargets}
+        />
+        <div className="mt-4 grid gap-3 rounded-lg bg-slate-900/70 p-4 text-sm text-slate-200 shadow-inner">
+          <div>
+            <span className="font-semibold text-slate-100">Edit Mode:</span> Snap parts,
+            adjust transforms, and configure joints. Gravity is disabled to make
+            precise placement easier.
+          </div>
+          <div>
+            <span className="font-semibold text-slate-100">Simulate Mode:</span> Rapier
+            physics runs with gravity. Door joints respond to the angle slider,
+            and the rover wheel motors are mapped to the keyboard.
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default AssemblyEditor;

--- a/src/lib/builder/examples.ts
+++ b/src/lib/builder/examples.ts
@@ -1,0 +1,510 @@
+import type { Blueprint, Catalog, Transform } from "./model";
+import { DEG2RAD, eulerToQuaternion } from "./math";
+import { cloneBlueprint } from "./utils";
+
+function rotationFromEulerDegrees(
+  x: number,
+  y: number,
+  z: number,
+): Transform["rotationQuat"] {
+  return eulerToQuaternion([x * DEG2RAD, y * DEG2RAD, z * DEG2RAD]);
+}
+
+function transform(
+  position: [number, number, number],
+  rotation: [number, number, number] = [0, 0, 0],
+): Transform {
+  return {
+    position,
+    rotationQuat: rotationFromEulerDegrees(rotation[0], rotation[1], rotation[2]),
+  };
+}
+
+const identityQuat: Transform["rotationQuat"] = [0, 0, 0, 1];
+
+export const builderCatalog: Catalog = {
+  id: "core:builder_demo",
+  version: "0.1.0",
+  parts: {
+    "core:ground_plate_v1": {
+      id: "core:ground_plate_v1",
+      version: "1.0.0",
+      name: "Ground Plate 10m",
+      category: "structural",
+      physics: {
+        dynamic: false,
+        colliders: [
+          {
+            shape: "box",
+            params: [5, 0.1, 5],
+            material: { friction: 1 },
+          },
+        ],
+      },
+      sockets: [],
+      metadata: {
+        tags: ["ground", "foundation"],
+        color: "#4b5563",
+        dimensions: [10, 0.2, 10],
+      },
+    },
+    "core:floor_panel_v1": {
+      id: "core:floor_panel_v1",
+      version: "1.0.0",
+      name: "Floor Panel 4m",
+      category: "structural",
+      physics: {
+        dynamic: false,
+        colliders: [
+          {
+            shape: "box",
+            params: [2, 0.1, 2],
+            material: { friction: 1 },
+          },
+        ],
+      },
+      sockets: [],
+      metadata: {
+        tags: ["building", "floor"],
+        color: "#9ca3af",
+        dimensions: [4, 0.2, 4],
+      },
+    },
+    "core:wall_panel_v1": {
+      id: "core:wall_panel_v1",
+      version: "1.0.0",
+      name: "Wall Panel 4m",
+      category: "structural",
+      physics: {
+        dynamic: false,
+        colliders: [
+          {
+            shape: "box",
+            params: [2, 1.25, 0.1],
+            material: { friction: 1 },
+          },
+        ],
+      },
+      sockets: [
+        {
+          id: "edge_left",
+          kind: "structural",
+          type: "grid:4m",
+          frame: transform([-2, 0, 0]),
+        },
+        {
+          id: "edge_right",
+          kind: "structural",
+          type: "grid:4m",
+          frame: transform([2, 0, 0]),
+        },
+        {
+          id: "door_mount_left",
+          kind: "mechanical",
+          type: "hinge:door",
+          tags: ["door", "mount"],
+          frame: {
+            position: [-1.5, -0.25, 0],
+            rotationQuat: identityQuat,
+          },
+          allowedMates: ["hinge:door"],
+          defaultJoint: "core:door_hinge",
+        },
+      ],
+      metadata: {
+        tags: ["building", "wall"],
+        color: "#cbd5f5",
+        dimensions: [4, 2.5, 0.2],
+      },
+    },
+    "core:roof_flat_v1": {
+      id: "core:roof_flat_v1",
+      version: "1.0.0",
+      name: "Roof Panel 4m",
+      category: "structural",
+      physics: {
+        dynamic: false,
+        colliders: [
+          {
+            shape: "box",
+            params: [2.2, 0.1, 2.2],
+            material: { friction: 0.6 },
+          },
+        ],
+      },
+      sockets: [],
+      metadata: {
+        tags: ["building", "roof"],
+        color: "#dc2626",
+        dimensions: [4.4, 0.2, 4.4],
+      },
+    },
+    "core:door_single_v1": {
+      id: "core:door_single_v1",
+      version: "1.0.0",
+      name: "Door (Left Hinge)",
+      category: "structural",
+      physics: {
+        dynamic: true,
+        mass: 25,
+        colliders: [
+          {
+            shape: "box",
+            params: [0.5, 1, 0.05],
+            material: { friction: 0.8 },
+          },
+        ],
+      },
+      sockets: [
+        {
+          id: "hinge",
+          kind: "mechanical",
+          type: "hinge:door",
+          frame: {
+            position: [-0.5, 0, 0],
+            rotationQuat: identityQuat,
+          },
+          allowedMates: ["hinge:door"],
+          defaultJoint: "core:door_hinge",
+        },
+      ],
+      metadata: {
+        tags: ["door"],
+        color: "#92400e",
+        dimensions: [1, 2, 0.1],
+      },
+    },
+    "veh:chassis_light_v1": {
+      id: "veh:chassis_light_v1",
+      version: "1.0.0",
+      name: "Light Chassis",
+      category: "mechanical",
+      physics: {
+        dynamic: true,
+        mass: 120,
+        colliders: [
+          {
+            shape: "box",
+            params: [0.7, 0.2, 1.2],
+            material: { friction: 0.8 },
+          },
+        ],
+      },
+      sockets: [
+        {
+          id: "wheel_fl",
+          kind: "mechanical",
+          type: "axle:drive",
+          tags: ["wheel", "front", "left"],
+          frame: {
+            position: [-0.9, -0.25, 1.1],
+            rotationQuat: rotationFromEulerDegrees(0, 0, 90),
+          },
+          allowedMates: ["axle:drive"],
+          defaultJoint: "veh:wheel_axle",
+        },
+        {
+          id: "wheel_fr",
+          kind: "mechanical",
+          type: "axle:drive",
+          tags: ["wheel", "front", "right"],
+          frame: {
+            position: [0.9, -0.25, 1.1],
+            rotationQuat: rotationFromEulerDegrees(0, 0, 90),
+          },
+          allowedMates: ["axle:drive"],
+          defaultJoint: "veh:wheel_axle",
+        },
+        {
+          id: "wheel_rl",
+          kind: "mechanical",
+          type: "axle:drive",
+          tags: ["wheel", "rear", "left"],
+          frame: {
+            position: [-0.9, -0.25, -1.1],
+            rotationQuat: rotationFromEulerDegrees(0, 0, 90),
+          },
+          allowedMates: ["axle:drive"],
+          defaultJoint: "veh:wheel_axle",
+        },
+        {
+          id: "wheel_rr",
+          kind: "mechanical",
+          type: "axle:drive",
+          tags: ["wheel", "rear", "right"],
+          frame: {
+            position: [0.9, -0.25, -1.1],
+            rotationQuat: rotationFromEulerDegrees(0, 0, 90),
+          },
+          allowedMates: ["axle:drive"],
+          defaultJoint: "veh:wheel_axle",
+        },
+      ],
+      metadata: {
+        tags: ["vehicle", "chassis"],
+        color: "#111827",
+        dimensions: [1.4, 0.4, 2.4],
+      },
+    },
+    "veh:wheel_drive_v1": {
+      id: "veh:wheel_drive_v1",
+      version: "1.0.0",
+      name: "Drive Wheel",
+      category: "mechanical",
+      physics: {
+        dynamic: true,
+        mass: 12,
+        colliders: [
+          {
+            shape: "cylinder",
+            params: [0.35, 0.12],
+            offset: {
+              position: [0, 0, 0],
+              rotationQuat: rotationFromEulerDegrees(0, 0, 90),
+            },
+            material: { friction: 1.5 },
+          },
+        ],
+      },
+      sockets: [
+        {
+          id: "axle",
+          kind: "mechanical",
+          type: "axle:drive",
+          tags: ["wheel"],
+          frame: {
+            position: [0, 0, 0],
+            rotationQuat: rotationFromEulerDegrees(0, 0, 90),
+          },
+          allowedMates: ["axle:drive"],
+          defaultJoint: "veh:wheel_axle",
+        },
+      ],
+      metadata: {
+        tags: ["vehicle", "wheel"],
+        color: "#111111",
+        dimensions: [0.7, 0.24, 0.7],
+      },
+      components: [
+        { kind: "Wheel", radius: 0.35, width: 0.24 },
+        {
+          kind: "Motor",
+          axis: "x",
+          nominalPower: 2500,
+          maxTorque: 320,
+          maxRPM: 1200,
+        },
+      ],
+    },
+  },
+  jointTemplates: {
+    "core:fixed_weld": {
+      id: "core:fixed_weld",
+      type: "fixed",
+      friction: 1,
+    },
+    "core:door_hinge": {
+      id: "core:door_hinge",
+      type: "revolute",
+      axis: [0, 1, 0],
+      limits: { lower: 0, upper: Math.PI * 0.9 },
+      drive: {
+        mode: "position",
+        target: 0,
+        stiffness: 40,
+        damping: 6,
+        maxForce: 120,
+      },
+      friction: 1.2,
+    },
+    "veh:wheel_axle": {
+      id: "veh:wheel_axle",
+      type: "revolute",
+      axis: [1, 0, 0],
+      drive: {
+        mode: "velocity",
+        target: 0,
+        maxForce: 450,
+        damping: 1,
+      },
+      friction: 0.2,
+    },
+  },
+  materials: {},
+};
+
+export const houseBlueprint: Blueprint = {
+  id: "bp:demo_house",
+  version: "0.1.0",
+  name: "Demo House",
+  root: {
+    id: "asm:house_root",
+    name: "House",
+    bakePolicy: "articulated",
+    metadata: {
+      kind: "structure",
+    },
+    parts: [
+      {
+        id: "house_ground",
+        partId: "core:ground_plate_v1",
+        transform: transform([0, -0.1, 0]),
+        label: "Ground",
+      },
+      {
+        id: "house_floor",
+        partId: "core:floor_panel_v1",
+        transform: transform([0, 0.1, 0]),
+        label: "Floor",
+      },
+      {
+        id: "house_wall_front",
+        partId: "core:wall_panel_v1",
+        transform: transform([0, 1.35, 1.9]),
+        label: "Front Wall",
+      },
+      {
+        id: "house_wall_back",
+        partId: "core:wall_panel_v1",
+        transform: transform([0, 1.35, -1.9], [0, 180, 0]),
+        label: "Back Wall",
+      },
+      {
+        id: "house_wall_left",
+        partId: "core:wall_panel_v1",
+        transform: transform([-1.9, 1.35, 0], [0, 90, 0]),
+        label: "Left Wall",
+      },
+      {
+        id: "house_wall_right",
+        partId: "core:wall_panel_v1",
+        transform: transform([1.9, 1.35, 0], [0, -90, 0]),
+        label: "Right Wall",
+      },
+      {
+        id: "house_roof",
+        partId: "core:roof_flat_v1",
+        transform: transform([0, 2.7, 0]),
+        label: "Roof",
+      },
+      {
+        id: "house_door",
+        partId: "core:door_single_v1",
+        transform: transform([-1.5, 1, 1.9]),
+        label: "Door",
+      },
+    ],
+    joints: [
+      {
+        id: "house_door_hinge",
+        a: { partInstanceId: "house_wall_front", socketId: "door_mount_left" },
+        b: { partInstanceId: "house_door", socketId: "hinge" },
+        template: "core:door_hinge",
+        limitsOverride: { lower: 0, upper: Math.PI * 0.85 },
+        tags: ["door", "hinge"],
+      },
+    ],
+  },
+};
+
+export const carBlueprint: Blueprint = {
+  id: "bp:demo_car",
+  version: "0.1.0",
+  name: "Demo Rover",
+  root: {
+    id: "asm:car_root",
+    name: "Vehicle",
+    bakePolicy: "articulated",
+    metadata: {
+      kind: "vehicle",
+      controllers: ["drive"],
+    },
+    parts: [
+      {
+        id: "car_ground",
+        partId: "core:ground_plate_v1",
+        transform: transform([0, -0.1, 0]),
+        label: "Ground",
+      },
+      {
+        id: "car_chassis",
+        partId: "veh:chassis_light_v1",
+        transform: transform([0, 0.65, 0]),
+        label: "Chassis",
+      },
+      {
+        id: "car_wheel_fl",
+        partId: "veh:wheel_drive_v1",
+        transform: transform([-0.9, 0.35, 1.1]),
+        label: "Wheel FL",
+      },
+      {
+        id: "car_wheel_fr",
+        partId: "veh:wheel_drive_v1",
+        transform: transform([0.9, 0.35, 1.1]),
+        label: "Wheel FR",
+      },
+      {
+        id: "car_wheel_rl",
+        partId: "veh:wheel_drive_v1",
+        transform: transform([-0.9, 0.35, -1.1]),
+        label: "Wheel RL",
+      },
+      {
+        id: "car_wheel_rr",
+        partId: "veh:wheel_drive_v1",
+        transform: transform([0.9, 0.35, -1.1]),
+        label: "Wheel RR",
+      },
+    ],
+    joints: [
+      {
+        id: "car_joint_fl",
+        a: { partInstanceId: "car_chassis", socketId: "wheel_fl" },
+        b: { partInstanceId: "car_wheel_fl", socketId: "axle" },
+        template: "veh:wheel_axle",
+        tags: ["wheel", "drive", "left", "front"],
+      },
+      {
+        id: "car_joint_fr",
+        a: { partInstanceId: "car_chassis", socketId: "wheel_fr" },
+        b: { partInstanceId: "car_wheel_fr", socketId: "axle" },
+        template: "veh:wheel_axle",
+        tags: ["wheel", "drive", "right", "front"],
+      },
+      {
+        id: "car_joint_rl",
+        a: { partInstanceId: "car_chassis", socketId: "wheel_rl" },
+        b: { partInstanceId: "car_wheel_rl", socketId: "axle" },
+        template: "veh:wheel_axle",
+        tags: ["wheel", "drive", "left", "rear"],
+      },
+      {
+        id: "car_joint_rr",
+        a: { partInstanceId: "car_chassis", socketId: "wheel_rr" },
+        b: { partInstanceId: "car_wheel_rr", socketId: "axle" },
+        template: "veh:wheel_axle",
+        tags: ["wheel", "drive", "right", "rear"],
+      },
+    ],
+  },
+};
+
+export const editorExamples = {
+  house: {
+    id: "house",
+    label: "House Blueprint",
+    blueprint: cloneBlueprint(houseBlueprint),
+  },
+  car: {
+    id: "car",
+    label: "Vehicle Blueprint",
+    blueprint: cloneBlueprint(carBlueprint),
+  },
+} as const;
+
+export type ExampleId = keyof typeof editorExamples;
+
+export function getExampleBlueprint(id: ExampleId): Blueprint {
+  return cloneBlueprint(editorExamples[id].blueprint);
+}

--- a/src/lib/builder/math.ts
+++ b/src/lib/builder/math.ts
@@ -1,0 +1,66 @@
+import { Euler, Quaternion, Vector3 } from "three";
+import type { Transform } from "./model";
+
+export const DEG2RAD = Math.PI / 180;
+export const RAD2DEG = 180 / Math.PI;
+
+export function toQuaternion(quat: Transform["rotationQuat"]): Quaternion {
+  const [x, y, z, w] = quat;
+  return new Quaternion(x, y, z, w);
+}
+
+export function toVector(vec: Transform["position"]): Vector3 {
+  const [x, y, z] = vec;
+  return new Vector3(x, y, z);
+}
+
+export function transformPoint(
+  transform: Transform,
+  localPoint: [number, number, number],
+): Vector3 {
+  const point = toVector(localPoint);
+  return point.applyQuaternion(toQuaternion(transform.rotationQuat)).add(
+    toVector(transform.position),
+  );
+}
+
+export function transformQuaternion(
+  transform: Transform,
+  localRotation: [number, number, number, number],
+): Quaternion {
+  const parent = toQuaternion(transform.rotationQuat);
+  const child = toQuaternion(localRotation);
+  return parent.multiply(child);
+}
+
+export function multiplyTransforms(
+  parent: Transform,
+  child: Transform,
+): Transform {
+  const position = transformPoint(parent, child.position);
+  const rotation = transformQuaternion(parent, child.rotationQuat);
+  return {
+    position: [position.x, position.y, position.z],
+    rotationQuat: [rotation.x, rotation.y, rotation.z, rotation.w],
+  };
+}
+
+export function quaternionToEuler(quat: Transform["rotationQuat"]): [number, number, number] {
+  const q = toQuaternion(quat);
+  const euler = new Euler().setFromQuaternion(q, "XYZ");
+  return [euler.x, euler.y, euler.z];
+}
+
+export function eulerToQuaternion(euler: [number, number, number]): Transform["rotationQuat"] {
+  const [x, y, z] = euler;
+  const q = new Quaternion().setFromEuler(new Euler(x, y, z, "XYZ"));
+  return [q.x, q.y, q.z, q.w];
+}
+
+export function vectorToArray(vec: Vector3): [number, number, number] {
+  return [vec.x, vec.y, vec.z];
+}
+
+export function quaternionToArray(q: Quaternion): [number, number, number, number] {
+  return [q.x, q.y, q.z, q.w];
+}

--- a/src/lib/builder/model.ts
+++ b/src/lib/builder/model.ts
@@ -1,0 +1,349 @@
+export type SemVer = `${number}.${number}.${number}`;
+export type UUID = string;
+export type Meters = number;
+export type Kilograms = number;
+export type Radians = number;
+export type Watts = number;
+
+export interface Transform {
+  position: [number, number, number];
+  rotationQuat: [number, number, number, number];
+  scale?: [number, number, number];
+}
+
+export interface Catalog {
+  id: string;
+  version: SemVer;
+  parts: Record<string, PartDef>;
+  prefabs?: Record<string, PrefabDef>;
+  materials?: Record<string, MaterialDef>;
+  jointTemplates?: Record<string, JointTemplate>;
+  rules?: MateRule[];
+}
+
+export interface PrefabDef {
+  id: string;
+  version: SemVer;
+  name: string;
+  assembly: Assembly;
+  params?: ParamDef[];
+}
+
+export interface PartDef {
+  id: string;
+  version: SemVer;
+  name: string;
+  category:
+    | "structural"
+    | "mechanical"
+    | "electrical"
+    | "fluid"
+    | "decor"
+    | "logic";
+  render?: {
+    gltf?: string;
+    node?: string;
+    scale?: number;
+    icon?: string;
+  };
+  physics?: {
+    dynamic: boolean;
+    mass?: Kilograms;
+    inertiaTensor?: number[];
+    colliders: ColliderDef[];
+  };
+  sockets: SocketDef[];
+  ports?: {
+    power?: PowerPortDef[];
+    signal?: SignalPortDef[];
+    fluid?: FluidPortDef[];
+    inventory?: ConveyorPortDef[];
+  };
+  components?: ComponentDef[];
+  params?: ParamDef[];
+  metadata?: Meta & {
+    dimensions?: [number, number, number];
+    color?: string;
+  };
+}
+
+export interface SocketDef {
+  id: string;
+  kind:
+    | "structural"
+    | "mechanical"
+    | "electrical"
+    | "fluid"
+    | "inventory"
+    | "decorative";
+  type: string;
+  gender?: "male" | "female" | "neutral";
+  tags?: string[];
+  frame: Transform;
+  allowedMates?: string[];
+  defaultJoint?: string;
+}
+
+export interface JointTemplate {
+  id: string;
+  type: "fixed" | "revolute" | "prismatic" | "spherical" | "d6";
+  axis?: [number, number, number];
+  limits?: { lower: number; upper: number };
+  drive?: {
+    mode: "velocity" | "position" | "spring";
+    target?: number;
+    stiffness?: number;
+    damping?: number;
+    maxForce?: number;
+  };
+  friction?: number;
+  breakable?: { force: number; torque: number };
+  metadata?: Record<string, unknown>;
+}
+
+export interface MateRule {
+  fromType: string;
+  toType: string;
+  joint: string;
+  alignment?: "coincident" | "coaxial" | "planar";
+}
+
+export interface ParamDef {
+  id: string;
+  type: "float" | "int" | "bool" | "enum" | "vec3" | "color";
+  default: unknown;
+  min?: number;
+  max?: number;
+  step?: number;
+  description?: string;
+}
+
+export interface MaterialDef {
+  id: string;
+  density?: number;
+  friction?: number;
+  restitution?: number;
+  pbr?: Record<string, unknown>;
+}
+
+export interface ColliderDef {
+  shape: "box" | "sphere" | "capsule" | "cylinder" | "convexHull" | "mesh";
+  params: number[];
+  offset?: Transform;
+  material?: { friction?: number; restitution?: number };
+}
+
+export interface PowerPortDef {
+  id: string;
+  role: "source" | "sink" | "both";
+  voltage?: number;
+  maxCurrent?: number;
+  connector: string;
+  frame: Transform;
+}
+
+export interface SignalPortDef {
+  id: string;
+  channels: Record<string, "digital" | "analog">;
+  frame: Transform;
+}
+
+export interface FluidPortDef {
+  id: string;
+  medium: "air" | "water" | "fuel" | "oil";
+  maxFlow?: number;
+  frame: Transform;
+}
+
+export interface ConveyorPortDef {
+  id: string;
+  size: "small" | "medium" | "large";
+  direction: "in" | "out" | "both";
+  frame: Transform;
+}
+
+export type ComponentDef =
+  | MotorDef
+  | WheelDef
+  | SuspensionDef
+  | BatteryDef
+  | GearboxDef
+  | SensorDef
+  | ControllerDef
+  | LightDef;
+
+export interface MotorDef {
+  kind: "Motor";
+  axis: "x" | "y" | "z" | "custom";
+  drivesSocket?: string;
+  nominalPower: Watts;
+  maxTorque: number;
+  maxRPM: number;
+  torqueCurve?: number[];
+  efficiency?: number;
+  defaultControl?: Record<string, unknown>;
+}
+
+export interface WheelDef {
+  kind: "Wheel";
+  radius: Meters;
+  width: Meters;
+  usesRaycast?: boolean;
+}
+
+export interface SuspensionDef {
+  kind: "Suspension";
+  travel: Meters;
+  stiffness: number;
+  damping: number;
+}
+
+export interface BatteryDef {
+  kind: "Battery";
+  capacityWh: number;
+  maxDischargeW: Watts;
+  maxChargeW?: Watts;
+}
+
+export interface GearboxDef {
+  kind: "Gearbox";
+  ratios: number[];
+  efficiency?: number;
+}
+
+export interface SensorDef {
+  kind: "Sensor";
+  type: "rpm" | "torque" | "voltage" | "contact" | "imu" | "custom";
+  port?: string;
+}
+
+export interface ControllerDef {
+  kind: "Controller";
+  script?: string;
+  inputs?: string[];
+  outputs?: string[];
+}
+
+export interface LightDef {
+  kind: "Light";
+  lumens: number;
+  powerDraw: Watts;
+}
+
+export interface Meta {
+  author?: string;
+  license?: string;
+  tags?: string[];
+  cost?: number;
+  description?: string;
+}
+
+export interface Blueprint {
+  id: UUID;
+  name: string;
+  version: SemVer;
+  root: Assembly;
+}
+
+export interface Assembly {
+  id: UUID;
+  name?: string;
+  parts: PartInstance[];
+  joints: JointInstance[];
+  networks?: NetworkConnection[];
+  groups?: Group[];
+  bakePolicy?: "articulated" | "compound" | "grid-merge";
+  metadata?: Record<string, unknown>;
+}
+
+export interface PartInstance {
+  id: UUID;
+  partId: string;
+  partVersion?: SemVer;
+  transform: Transform;
+  paramOverrides?: Record<string, unknown>;
+  materialOverrides?: Record<string, unknown>;
+  label?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface JointInstance {
+  id: UUID;
+  a: InstanceSocketRef;
+  b: InstanceSocketRef;
+  template: string;
+  anchorAOverride?: Transform;
+  anchorBOverride?: Transform;
+  limitsOverride?: { lower: number; upper: number };
+  driveOverride?: { target?: number; stiffness?: number; damping?: number; maxForce?: number };
+  articulationGroup?: string;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface InstanceSocketRef {
+  partInstanceId: UUID;
+  socketId: string;
+}
+
+export interface NetworkConnection {
+  id: UUID;
+  kind: "power" | "signal" | "fluid" | "inventory";
+  from: InstancePortRef;
+  to: InstancePortRef;
+  properties?: Record<string, unknown>;
+}
+
+export interface InstancePortRef {
+  partInstanceId: UUID;
+  portId: string;
+}
+
+export interface Group {
+  id: UUID;
+  name?: string;
+  partIds: UUID[];
+}
+
+export interface RuntimeState {
+  parts: Record<UUID, PartRuntime>;
+  joints: Record<UUID, JointRuntime>;
+  networks: Record<UUID, NetworkRuntime>;
+  telemetry?: Record<string, unknown>;
+}
+
+export interface PartRuntime {
+  health: number;
+  temperature?: number;
+  powered?: boolean;
+  powerInW?: number;
+  powerOutW?: number;
+  dynamic?: {
+    velocity: [number, number, number];
+    omega: [number, number, number];
+    asleep: boolean;
+  };
+  sensors?: Record<string, number>;
+}
+
+export interface JointRuntime {
+  angle?: number;
+  position?: number;
+  motor?: { enabled: boolean; target?: number; current?: number };
+  broken?: boolean;
+}
+
+export interface NetworkRuntime {
+  power?: { voltage: number; current: number };
+  signal?: Record<string, number>;
+  fluid?: { flow: number; pressure: number };
+  inventory?: { rate: number; capacity: number };
+}
+
+export interface Inventory {
+  parts: string[];
+  prefabs: string[];
+  quantities?: Record<string, number>;
+  favorites?: string[];
+  lastUsed?: string[];
+}

--- a/src/lib/builder/utils.ts
+++ b/src/lib/builder/utils.ts
@@ -1,0 +1,41 @@
+import type { Blueprint, JointInstance, PartInstance, Transform } from "./model";
+
+export function cloneBlueprint<T>(value: T): T {
+  if (typeof structuredClone === "function") {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function findPartInstance(
+  blueprint: Blueprint,
+  partInstanceId: string,
+): PartInstance | undefined {
+  return blueprint.root.parts.find((part) => part.id === partInstanceId);
+}
+
+export function updatePartTransform(
+  blueprint: Blueprint,
+  partInstanceId: string,
+  transform: Transform,
+): Blueprint {
+  const next = cloneBlueprint(blueprint);
+  const part = findPartInstance(next, partInstanceId);
+  if (!part) {
+    return blueprint;
+  }
+  part.transform = transform;
+  return next;
+}
+
+export function findJointByTag(
+  blueprint: Blueprint,
+  tag: string,
+): JointInstance | undefined {
+  return blueprint.root.joints.find((joint) => joint.tags?.includes(tag));
+}
+
+export function partLabel(part: PartInstance, fallback?: string): string {
+  if (part.label) return part.label;
+  return fallback ?? part.id;
+}


### PR DESCRIPTION
## Summary
- define a reusable assembly data model plus catalog content and demo blueprints for a house and drivable rover
- build a React Three Fiber + Rapier canvas with transform controls, joint registration, and keyboard-driven articulations
- add an editor interface and page that ships the house and vehicle scenes with interactive editing and simulation, and link it from the homepage

## Testing
- `npm run lint` *(fails: biome binary is unavailable because npm install cannot download onnxruntime-node in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c94c903238832fbb3f6aeca284b9b6