### PR TITLE
feat: add volumetric fire demo

### DIFF
--- a/src/app/three-fire/page.tsx
+++ b/src/app/three-fire/page.tsx
@@ -1,0 +1,411 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import * as THREE from 'three';
+import {
+  VolumetricFire,
+  type FlameControls,
+  type SmokeControls,
+} from '@/components/three/fire/VolumetricFire';
+
+interface ControlSliderProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  formatValue?: (value: number) => string;
+  onChange: (value: number) => void;
+}
+
+function ControlSlider({
+  label,
+  value,
+  min,
+  max,
+  step = 0.01,
+  formatValue,
+  onChange,
+}: ControlSliderProps) {
+  const displayValue = formatValue ? formatValue(value) : value.toFixed(step < 1 ? 2 : 0);
+  return (
+    <label className="block space-y-1">
+      <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.2em] text-white/60">
+        <span>{label}</span>
+        <span className="font-mono text-white/80">{displayValue}</span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        className="w-full cursor-pointer appearance-none rounded-full bg-white/10 accent-orange-500"
+      />
+    </label>
+  );
+}
+
+interface ColorControlProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function ColorControl({ label, value, onChange }: ColorControlProps) {
+  return (
+    <label className="flex items-center justify-between text-[11px] uppercase tracking-[0.2em] text-white/60">
+      <span>{label}</span>
+      <input
+        type="color"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-8 w-14 cursor-pointer rounded border border-white/20 bg-transparent"
+      />
+    </label>
+  );
+}
+
+interface FireCanvasProps {
+  flameControls: FlameControls;
+  smokeControls: SmokeControls;
+  autoRotate: boolean;
+}
+
+function FireCanvas({ flameControls, smokeControls, autoRotate }: FireCanvasProps) {
+  return (
+    <Canvas
+      shadows
+      dpr={[1, 1.75]}
+      camera={{ position: [10, 5, 11], fov: 45, near: 0.1, far: 80 }}
+      gl={{ antialias: true }}
+    >
+      <color attach="background" args={['#04070f']} />
+      <fog attach="fog" args={['#050912', 14, 42]} />
+      <ambientLight intensity={0.25} />
+      <directionalLight
+        castShadow
+        position={[6, 12, 6]}
+        intensity={2.2}
+        color={new THREE.Color('#ffdab1')}
+        shadow-mapSize-width={2048}
+        shadow-mapSize-height={2048}
+        shadow-camera-near={1}
+        shadow-camera-far={40}
+        shadow-camera-left={-18}
+        shadow-camera-right={18}
+        shadow-camera-top={18}
+        shadow-camera-bottom={-18}
+      />
+      <directionalLight position={[-8, 6, -6]} intensity={0.65} color={new THREE.Color('#1b2f66')} />
+      <pointLight position={[0, 5, 0]} intensity={1.2} color={new THREE.Color('#ff8b3d')} distance={36} />
+      <FireObjects flameControls={flameControls} smokeControls={smokeControls} />
+      <OrbitControls
+        enableDamping
+        dampingFactor={0.08}
+        minDistance={6}
+        maxDistance={32}
+        maxPolarAngle={Math.PI / 2.05}
+        target={[0, 1.6, 0]}
+        autoRotate={autoRotate}
+        autoRotateSpeed={0.35}
+      />
+    </Canvas>
+  );
+}
+
+interface FireObjectsProps {
+  flameControls: FlameControls;
+  smokeControls: SmokeControls;
+}
+
+function FireObjects({ flameControls, smokeControls }: FireObjectsProps) {
+  const planeSmoke = useMemo(() => ({
+    ...smokeControls,
+    rise: smokeControls.rise * 0.75,
+    size: smokeControls.size * 1.25,
+    drift: smokeControls.drift * 0.6,
+  }), [smokeControls]);
+
+  const knotSmoke = useMemo(() => ({
+    ...smokeControls,
+    rise: smokeControls.rise * 1.2,
+    drift: smokeControls.drift * 1.25,
+    size: smokeControls.size * 0.9,
+  }), [smokeControls]);
+
+  return (
+    <group>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.06, 0]} receiveShadow>
+        <circleGeometry args={[18, 64]} />
+        <meshStandardMaterial color="#05070f" roughness={1} metalness={0} />
+      </mesh>
+
+      <group position={[-6.3, 0.1, 0]}>
+        <mesh rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+          <planeGeometry args={[8, 8, 1, 1]} />
+          <meshStandardMaterial color="#111622" roughness={0.96} metalness={0.08} />
+        </mesh>
+        <VolumetricFire
+          position={[0, 0.05, 0]}
+          rotation={[-Math.PI / 2, 0, 0]}
+          shape={{ kind: 'plane', width: 8, height: 8 }}
+          flameCount={2400}
+          smokeCount={900}
+          spread={1.55}
+          heightSpread={0.35}
+          flameControls={flameControls}
+          smokeControls={planeSmoke}
+        />
+      </group>
+
+      <group position={[0, 1.6, 0]}>
+        <mesh castShadow>
+          <sphereGeometry args={[1.6, 96, 64]} />
+          <meshStandardMaterial
+            color="#151b2c"
+            roughness={0.82}
+            metalness={0.18}
+            emissive="#1f2538"
+            emissiveIntensity={0.18}
+          />
+        </mesh>
+        <VolumetricFire
+          shape={{ kind: 'sphere', radius: 1.6 }}
+          flameCount={1900}
+          smokeCount={620}
+          spread={1.0}
+          heightSpread={1.08}
+          flameControls={flameControls}
+          smokeControls={smokeControls}
+        />
+      </group>
+
+      <group position={[6.3, 1.2, 0]}>
+        <mesh castShadow>
+          <boxGeometry args={[2.4, 2.4, 2.4]} />
+          <meshStandardMaterial
+            color="#121827"
+            roughness={0.88}
+            metalness={0.12}
+            emissive="#131b2b"
+            emissiveIntensity={0.12}
+          />
+        </mesh>
+        <VolumetricFire
+          shape={{ kind: 'box', width: 2.4, height: 2.4, depth: 2.4 }}
+          flameCount={1700}
+          smokeCount={540}
+          spread={0.9}
+          heightSpread={1.1}
+          flameControls={flameControls}
+          smokeControls={smokeControls}
+        />
+      </group>
+
+      <group position={[0, 1.1, -6.3]}>
+        <mesh castShadow rotation={[Math.PI / 2.4, 0, 0]}>
+          <torusKnotGeometry args={[1.4, 0.45, 220, 32, 2, 5]} />
+          <meshStandardMaterial
+            color="#171f33"
+            roughness={0.76}
+            metalness={0.22}
+            emissive="#151d30"
+            emissiveIntensity={0.16}
+          />
+        </mesh>
+        <VolumetricFire
+          shape={{ kind: 'torus', radius: 1.4, tube: 0.45, tubularSegments: 220, radialSegments: 28, p: 2, q: 5 }}
+          flameCount={2100}
+          smokeCount={520}
+          spread={0.7}
+          heightSpread={0.9}
+          flameControls={flameControls}
+          smokeControls={knotSmoke}
+        />
+      </group>
+    </group>
+  );
+}
+
+export default function ThreeFirePage() {
+  const [flameSpeed, setFlameSpeed] = useState(0.68);
+  const [flameRise, setFlameRise] = useState(3.2);
+  const [flameSize, setFlameSize] = useState(64);
+  const [flameDistortion, setFlameDistortion] = useState(1.15);
+  const [flameFlow, setFlameFlow] = useState(0.75);
+  const [flameIntensity, setFlameIntensity] = useState(2.35);
+  const [flameFlicker, setFlameFlicker] = useState(1.0);
+  const [flameOpacity, setFlameOpacity] = useState(0.95);
+  const [flameNoise, setFlameNoise] = useState(0.34);
+  const [innerColor, setInnerColor] = useState('#ffd6a8');
+  const [outerColor, setOuterColor] = useState('#ff5205');
+
+  const [smokeEnabled, setSmokeEnabled] = useState(true);
+  const [smokeSpeed, setSmokeSpeed] = useState(0.2);
+  const [smokeRise, setSmokeRise] = useState(5.0);
+  const [smokeSize, setSmokeSize] = useState(46);
+  const [smokeOpacity, setSmokeOpacity] = useState(0.52);
+  const [smokeNoise, setSmokeNoise] = useState(0.28);
+  const [smokeDrift, setSmokeDrift] = useState(0.7);
+  const [smokeColor, setSmokeColor] = useState('#7f8aa1');
+
+  const [autoRotate, setAutoRotate] = useState(true);
+
+  const flameControls = useMemo<FlameControls>(
+    () => ({
+      speed: flameSpeed,
+      rise: flameRise,
+      size: flameSize,
+      distortion: flameDistortion,
+      flow: flameFlow,
+      intensity: flameIntensity,
+      flicker: flameFlicker,
+      opacity: flameOpacity,
+      noiseScale: flameNoise,
+      innerColor,
+      outerColor,
+    }),
+    [
+      flameDistortion,
+      flameFlicker,
+      flameFlow,
+      flameIntensity,
+      flameNoise,
+      flameOpacity,
+      flameRise,
+      flameSize,
+      flameSpeed,
+      innerColor,
+      outerColor,
+    ],
+  );
+
+  const smokeControls = useMemo<SmokeControls>(
+    () => ({
+      enabled: smokeEnabled,
+      speed: smokeSpeed,
+      rise: smokeRise,
+      size: smokeSize,
+      opacity: smokeOpacity,
+      noiseScale: smokeNoise,
+      drift: smokeDrift,
+      color: smokeColor,
+    }),
+    [smokeColor, smokeDrift, smokeEnabled, smokeNoise, smokeOpacity, smokeRise, smokeSize, smokeSpeed],
+  );
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-[#04050a] via-[#050918] to-[#0a1226] text-gray-100">
+      <div className="mx-auto flex max-w-7xl flex-col gap-10 px-6 py-12">
+        <header className="space-y-4 text-center lg:text-left">
+          <p className="text-sm uppercase tracking-[0.4em] text-orange-400">React Three Fiber</p>
+          <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
+            Volumetric Fire Playground
+          </h1>
+          <p className="mx-auto max-w-3xl text-base text-white/70 lg:mx-0 lg:text-lg">
+            Explore animated volumetric fire attached to a plane, sphere, cube, and torus knot. Tweak
+            the shader-driven flames and optional smoke in real time, then orbit around the scene to
+            inspect the lighting from every angle.
+          </p>
+        </header>
+
+        <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-black/40 shadow-2xl">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,#1d253d_0%,transparent_60%)] opacity-70" />
+          <div className="relative h-[720px] w-full">
+            <FireCanvas flameControls={flameControls} smokeControls={smokeControls} autoRotate={autoRotate} />
+            <div className="pointer-events-none absolute inset-0 flex items-start justify-between p-6">
+              <div className="pointer-events-auto w-full max-w-xs space-y-4 rounded-2xl bg-black/60 p-4 backdrop-blur">
+                <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-orange-300">Flames</h2>
+                <ControlSlider label="Speed" value={flameSpeed} min={0.2} max={1.5} step={0.01} onChange={setFlameSpeed} />
+                <ControlSlider label="Rise" value={flameRise} min={1.6} max={6} step={0.05} onChange={setFlameRise} />
+                <ControlSlider label="Size" value={flameSize} min={30} max={90} step={1} onChange={setFlameSize} />
+                <ControlSlider label="Distortion" value={flameDistortion} min={0} max={2.4} step={0.01} onChange={setFlameDistortion} />
+                <ControlSlider label="Flow" value={flameFlow} min={0} max={1.5} step={0.01} onChange={setFlameFlow} />
+                <ControlSlider label="Intensity" value={flameIntensity} min={1.2} max={3.5} step={0.01} onChange={setFlameIntensity} />
+                <ControlSlider label="Flicker" value={flameFlicker} min={0} max={2.5} step={0.01} onChange={setFlameFlicker} />
+                <ControlSlider label="Opacity" value={flameOpacity} min={0.3} max={1} step={0.01} onChange={setFlameOpacity} />
+                <ControlSlider label="Noise" value={flameNoise} min={0.15} max={0.65} step={0.01} onChange={setFlameNoise} />
+                <div className="grid grid-cols-2 gap-3 pt-1">
+                  <ColorControl label="Inner" value={innerColor} onChange={setInnerColor} />
+                  <ColorControl label="Outer" value={outerColor} onChange={setOuterColor} />
+                </div>
+              </div>
+
+              <div className="pointer-events-auto hidden max-w-xs space-y-4 rounded-2xl bg-black/55 p-4 backdrop-blur lg:block">
+                <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-300">Smoke</h2>
+                <label className="flex items-center justify-between text-[11px] uppercase tracking-[0.2em] text-white/60">
+                  <span>Enabled</span>
+                  <input
+                    type="checkbox"
+                    checked={smokeEnabled}
+                    onChange={(event) => setSmokeEnabled(event.target.checked)}
+                    className="h-5 w-5 cursor-pointer rounded border border-white/30 bg-black/40 text-orange-500"
+                  />
+                </label>
+                <ControlSlider label="Speed" value={smokeSpeed} min={0.05} max={0.6} step={0.01} onChange={setSmokeSpeed} />
+                <ControlSlider label="Rise" value={smokeRise} min={2} max={9} step={0.05} onChange={setSmokeRise} />
+                <ControlSlider label="Size" value={smokeSize} min={20} max={80} step={1} onChange={setSmokeSize} />
+                <ControlSlider label="Opacity" value={smokeOpacity} min={0.1} max={0.9} step={0.01} onChange={setSmokeOpacity} />
+                <ControlSlider label="Noise" value={smokeNoise} min={0.1} max={0.6} step={0.01} onChange={setSmokeNoise} />
+                <ControlSlider label="Drift" value={smokeDrift} min={0} max={1.6} step={0.01} onChange={setSmokeDrift} />
+                <ColorControl label="Color" value={smokeColor} onChange={setSmokeColor} />
+                <label className="mt-2 flex items-center justify-between text-[11px] uppercase tracking-[0.2em] text-white/60">
+                  <span>Auto Orbit</span>
+                  <input
+                    type="checkbox"
+                    checked={autoRotate}
+                    onChange={(event) => setAutoRotate(event.target.checked)}
+                    className="h-5 w-5 cursor-pointer rounded border border-white/30 bg-black/40 text-orange-500"
+                  />
+                </label>
+              </div>
+            </div>
+          </div>
+          <div className="pointer-events-none absolute bottom-4 left-0 right-0 mx-auto hidden max-w-md rounded-full border border-white/10 bg-black/50 px-6 py-2 text-center text-xs uppercase tracking-[0.3em] text-white/60 backdrop-blur sm:block">
+            Drag with your mouse or touch to orbit the camera around the inferno
+          </div>
+        </section>
+
+        <section className="grid gap-6 rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-lg lg:grid-cols-3">
+          <div className="space-y-2">
+            <h2 className="text-lg font-semibold tracking-tight text-white">Volumetric particles</h2>
+            <p className="text-sm text-white/70">
+              Thousands of shader-driven point sprites are sampled from each mesh surface, jittered into
+              the volume, and animated with procedural simplex noise to produce layered flames that wrap
+              any geometry.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-lg font-semibold tracking-tight text-white">Parametric fire shader</h2>
+            <p className="text-sm text-white/70">
+              The custom GLSL material combines noise-driven distortion, height-based color gradients,
+              and flicker controls so the same system can ignite planes, solids, or intricate shapes like
+              the torus knot.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-lg font-semibold tracking-tight text-white">Configurable smoke</h2>
+            <p className="text-sm text-white/70">
+              Optional smoke plumes rise with independent drift, size, and opacity controls to add depth
+              and atmosphere without heavy volumetric raymarching.
+            </p>
+          </div>
+        </section>
+
+        <div className="flex flex-wrap items-center justify-between gap-4 text-sm text-white/60">
+          <a href="/" className="rounded-full border border-white/30 px-4 py-2 transition hover:border-orange-400 hover:text-orange-300">
+            ← Back to home
+          </a>
+          <p className="text-xs uppercase tracking-[0.3em]">
+            Built with React Three Fiber · Three.js · Procedural shaders
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/three/fire/VolumetricFire.tsx
+++ b/src/components/three/fire/VolumetricFire.tsx
@@ -1,0 +1,608 @@
+'use client';
+
+import { shaderMaterial } from '@react-three/drei';
+import { extend, type Object3DNode, useFrame } from '@react-three/fiber';
+import { useEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { MeshSurfaceSampler } from 'three/examples/jsm/math/MeshSurfaceSampler.js';
+
+const noiseGLSL = /* glsl */ `
+vec3 mod289(vec3 x) {
+  return x - floor(x * (1.0 / 289.0)) * 289.0;
+}
+
+vec4 mod289(vec4 x) {
+  return x - floor(x * (1.0 / 289.0)) * 289.0;
+}
+
+vec4 permute(vec4 x) {
+  return mod289(((x * 34.0) + 1.0) * x);
+}
+
+vec4 taylorInvSqrt(vec4 r) {
+  return 1.79284291400159 - 0.85373472095314 * r;
+}
+
+float snoise(vec3 v) {
+  const vec2  C = vec2(1.0/6.0, 1.0/3.0) ;
+  const vec4  D = vec4(0.0, 0.5, 1.0, 2.0);
+
+  vec3 i  = floor(v + dot(v, C.yyy) );
+  vec3 x0 =   v - i + dot(i, C.xxx) ;
+
+  vec3 g = step(x0.yzx, x0.xyz);
+  vec3 l = 1.0 - g;
+  vec3 i1 = min( g.xyz, l.zxy );
+  vec3 i2 = max( g.xyz, l.zxy );
+
+  vec3 x1 = x0 - i1 + C.xxx;
+  vec3 x2 = x0 - i2 + C.yyy;
+  vec3 x3 = x0 - D.yyy;
+
+  i = mod289(i);
+  vec4 p = permute( permute( permute(
+             i.z + vec4(0.0, i1.z, i2.z, 1.0 ))
+           + i.y + vec4(0.0, i1.y, i2.y, 1.0 ))
+           + i.x + vec4(0.0, i1.x, i2.x, 1.0 ));
+
+  float n_ = 0.142857142857;
+  vec3  ns = n_ * D.wyz - D.xzx;
+
+  vec4 j = p - 49.0 * floor(p * ns.z * ns.z);
+
+  vec4 x_ = floor(j * ns.z);
+  vec4 y_ = floor(j - 7.0 * x_ );
+
+  vec4 x = x_ *ns.x + ns.yyyy;
+  vec4 y = y_ *ns.x + ns.yyyy;
+  vec4 h = 1.0 - abs(x) - abs(y);
+
+  vec4 b0 = vec4( x.xy, y.xy );
+  vec4 b1 = vec4( x.zw, y.zw );
+
+  vec4 s0 = floor(b0) * 2.0 + 1.0;
+  vec4 s1 = floor(b1) * 2.0 + 1.0;
+  vec4 sh = -step(h, vec4(0.0));
+
+  vec4 a0 = b0.xzyw + s0.xzyw * sh.xxyy ;
+  vec4 a1 = b1.xzyw + s1.xzyw * sh.zzww ;
+
+  vec3 p0 = vec3(a0.xy, h.x);
+  vec3 p1 = vec3(a0.zw, h.y);
+  vec3 p2 = vec3(a1.xy, h.z);
+  vec3 p3 = vec3(a1.zw, h.w);
+
+  vec4 norm = taylorInvSqrt(vec4(dot(p0,p0), dot(p1,p1), dot(p2,p2), dot(p3,p3)));
+  p0 *= norm.x;
+  p1 *= norm.y;
+  p2 *= norm.z;
+  p3 *= norm.w;
+
+  vec4 m = max(0.6 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.0);
+  m = m * m;
+  return 42.0 * dot( m*m, vec4( dot(p0,x0), dot(p1,x1),
+                                dot(p2,x2), dot(p3,x3) ) );
+}
+`;
+
+const fireVertexShader = /* glsl */ `
+precision highp float;
+
+uniform float uTime;
+uniform float uSpeed;
+uniform float uRise;
+uniform float uDistortion;
+uniform float uNoiseScale;
+uniform float uSize;
+uniform float uFlowStrength;
+
+attribute float aScale;
+attribute float aSeed;
+attribute vec3 aFlow;
+
+varying float vLife;
+varying float vSeed;
+varying float vNoise;
+
+${noiseGLSL}
+
+void main() {
+  float t = uTime * uSpeed;
+  float progress = fract(t + aSeed);
+  float life = 1.0 - progress;
+
+  vec3 pos = position;
+  vec3 noiseSample = pos * uNoiseScale + vec3(0.0, t * 0.5, aSeed * 10.0);
+  float n1 = snoise(noiseSample);
+  float n2 = snoise(noiseSample + 11.0);
+
+  pos.xz += vec2(n1, n2) * uDistortion;
+  pos.y += n1 * 0.5 * uDistortion;
+
+  pos.xz += normalize(vec2(aFlow.x, aFlow.z) + 0.0001) * uFlowStrength * progress * progress;
+  pos.y += progress * uRise;
+
+  vec4 mvPosition = modelViewMatrix * vec4(pos, 1.0);
+  float size = (aScale * 0.6 + life) * uSize;
+  gl_PointSize = clamp(size * (1.0 / -mvPosition.z), 6.0, 140.0);
+  gl_Position = projectionMatrix * mvPosition;
+
+  vLife = life;
+  vSeed = aSeed;
+  vNoise = n1;
+}
+`;
+
+const fireFragmentShader = /* glsl */ `
+precision highp float;
+
+uniform float uTime;
+uniform float uOpacity;
+uniform float uIntensity;
+uniform float uFlickerStrength;
+uniform vec3 uColorInner;
+uniform vec3 uColorOuter;
+
+varying float vLife;
+varying float vSeed;
+varying float vNoise;
+
+void main() {
+  vec2 uv = gl_PointCoord * 2.0 - 1.0;
+  float dist = length(uv);
+  float falloff = smoothstep(1.0, 0.0, dist);
+  if (falloff <= 0.0) discard;
+
+  float flame = pow(falloff, uIntensity) * vLife;
+  float flicker = 0.85 + 0.15 * sin(uTime * 30.0 + vSeed * 40.0);
+  flicker += vNoise * 0.25 * uFlickerStrength;
+  flicker = clamp(flicker, 0.0, 1.6);
+
+  vec3 color = mix(uColorOuter, uColorInner, pow(vLife, 2.2));
+  color *= 1.2;
+
+  gl_FragColor = vec4(color * flame * flicker, flame * uOpacity);
+}
+`;
+
+const smokeVertexShader = /* glsl */ `
+precision highp float;
+
+uniform float uTime;
+uniform float uSpeed;
+uniform float uRise;
+uniform float uSize;
+uniform float uNoiseScale;
+uniform float uDrift;
+
+attribute float aScale;
+attribute float aSeed;
+attribute vec3 aFlow;
+
+varying float vAlpha;
+
+${noiseGLSL}
+
+void main() {
+  float t = uTime * uSpeed;
+  float progress = fract(t + aSeed);
+  vec3 pos = position;
+  float height = progress * uRise;
+  pos.y += height;
+
+  vec3 noiseSample = pos * uNoiseScale + vec3(aSeed * 10.0, t * 0.25, t * 0.5);
+  float driftX = snoise(noiseSample);
+  float driftZ = snoise(noiseSample + 19.5);
+  pos.x += (driftX + aFlow.x * 0.5) * uDrift;
+  pos.z += (driftZ + aFlow.z * 0.5) * uDrift;
+
+  vec4 mvPosition = modelViewMatrix * vec4(pos, 1.0);
+  float size = (aScale + progress * 2.0) * uSize;
+  gl_PointSize = clamp(size * (1.0 / -mvPosition.z), 4.0, 120.0);
+  gl_Position = projectionMatrix * mvPosition;
+
+  vAlpha = 1.0 - progress;
+}
+`;
+
+const smokeFragmentShader = /* glsl */ `
+precision highp float;
+
+uniform vec3 uColor;
+uniform float uOpacity;
+
+varying float vAlpha;
+
+void main() {
+  vec2 uv = gl_PointCoord * 2.0 - 1.0;
+  float dist = length(uv);
+  float alpha = smoothstep(1.0, 0.0, dist) * vAlpha * uOpacity;
+  if (alpha <= 0.0) discard;
+
+  gl_FragColor = vec4(uColor, alpha);
+}
+`;
+
+const FireParticlesMaterial = shaderMaterial(
+  {
+    uTime: 0,
+    uSpeed: 0.65,
+    uRise: 3.0,
+    uDistortion: 1.1,
+    uNoiseScale: 0.35,
+    uSize: 60.0,
+    uFlowStrength: 0.6,
+    uOpacity: 0.95,
+    uIntensity: 2.2,
+    uFlickerStrength: 1.0,
+    uColorInner: new THREE.Color('#ffd1a9'),
+    uColorOuter: new THREE.Color('#ff4d00'),
+  },
+  fireVertexShader,
+  fireFragmentShader,
+);
+
+const SmokeParticlesMaterial = shaderMaterial(
+  {
+    uTime: 0,
+    uSpeed: 0.15,
+    uRise: 5.0,
+    uSize: 45.0,
+    uNoiseScale: 0.25,
+    uDrift: 0.6,
+    uColor: new THREE.Color('#8d8d8d'),
+    uOpacity: 0.45,
+  },
+  smokeVertexShader,
+  smokeFragmentShader,
+);
+
+extend({ FireParticlesMaterial, SmokeParticlesMaterial });
+
+type FireParticlesMaterialType = InstanceType<typeof FireParticlesMaterial>;
+type SmokeParticlesMaterialType = InstanceType<typeof SmokeParticlesMaterial>;
+
+type FireMaterialInstance = FireParticlesMaterialType & {
+  uTime: number;
+  uSpeed: number;
+  uRise: number;
+  uDistortion: number;
+  uNoiseScale: number;
+  uSize: number;
+  uFlowStrength: number;
+  uOpacity: number;
+  uIntensity: number;
+  uFlickerStrength: number;
+  uColorInner: THREE.Color;
+  uColorOuter: THREE.Color;
+};
+
+type SmokeMaterialInstance = SmokeParticlesMaterialType & {
+  uTime: number;
+  uSpeed: number;
+  uRise: number;
+  uSize: number;
+  uNoiseScale: number;
+  uDrift: number;
+  uColor: THREE.Color;
+  uOpacity: number;
+};
+
+export type FireShape =
+  | { kind: 'plane'; width: number; height: number }
+  | { kind: 'sphere'; radius: number }
+  | { kind: 'box'; width: number; height: number; depth: number }
+  | {
+      kind: 'torus';
+      radius: number;
+      tube: number;
+      tubularSegments?: number;
+      radialSegments?: number;
+      p?: number;
+      q?: number;
+    };
+
+export interface FlameControls {
+  speed: number;
+  rise: number;
+  size: number;
+  distortion: number;
+  flow: number;
+  intensity: number;
+  flicker: number;
+  opacity: number;
+  noiseScale: number;
+  innerColor: string;
+  outerColor: string;
+}
+
+export interface SmokeControls {
+  enabled: boolean;
+  speed: number;
+  rise: number;
+  size: number;
+  opacity: number;
+  noiseScale: number;
+  drift: number;
+  color: string;
+}
+
+export interface VolumetricFireProps extends JSX.IntrinsicElements['group'] {
+  shape: FireShape;
+  flameCount?: number;
+  smokeCount?: number;
+  spread?: number;
+  heightSpread?: number;
+  flameControls: FlameControls;
+  smokeControls?: SmokeControls;
+}
+
+type FireGeometryAttributes = {
+  position: THREE.BufferAttribute;
+  aScale: THREE.BufferAttribute;
+  aSeed: THREE.BufferAttribute;
+  aFlow: THREE.BufferAttribute;
+};
+
+function createShapeMesh(shape: FireShape): THREE.Mesh {
+  switch (shape.kind) {
+    case 'plane': {
+      const geometry = new THREE.PlaneGeometry(shape.width, shape.height, 64, 64);
+      return new THREE.Mesh(geometry);
+    }
+    case 'sphere': {
+      const geometry = new THREE.SphereGeometry(shape.radius, 128, 64);
+      return new THREE.Mesh(geometry);
+    }
+    case 'box': {
+      const geometry = new THREE.BoxGeometry(
+        shape.width,
+        shape.height,
+        shape.depth,
+        48,
+        48,
+        48,
+      );
+      return new THREE.Mesh(geometry);
+    }
+    case 'torus': {
+      const geometry = new THREE.TorusKnotGeometry(
+        shape.radius,
+        shape.tube,
+        shape.tubularSegments ?? 180,
+        shape.radialSegments ?? 24,
+        shape.p ?? 2,
+        shape.q ?? 3,
+      );
+      return new THREE.Mesh(geometry);
+    }
+    default: {
+      const _exhaustive: never = shape;
+      return new THREE.Mesh();
+    }
+  }
+}
+
+function buildParticleGeometry(
+  shape: FireShape,
+  count: number,
+  spread: number,
+  heightSpread: number,
+): THREE.BufferGeometry<THREE.NormalBufferAttributes> {
+  const mesh = createShapeMesh(shape);
+  const sampler = new MeshSurfaceSampler(mesh).build();
+  const geometry = new THREE.BufferGeometry();
+
+  const positions = new Float32Array(count * 3);
+  const flows = new Float32Array(count * 3);
+  const scales = new Float32Array(count);
+  const seeds = new Float32Array(count);
+
+  const tempPosition = new THREE.Vector3();
+  const tempNormal = new THREE.Vector3();
+
+  for (let i = 0; i < count; i += 1) {
+    sampler.sample(tempPosition, tempNormal);
+
+    const surfaceJitter = (Math.random() - 0.25) * spread;
+    tempPosition.addScaledVector(tempNormal, surfaceJitter);
+    tempPosition.x += (Math.random() - 0.5) * spread;
+    tempPosition.z += (Math.random() - 0.5) * spread;
+    tempPosition.y += (Math.random() - 0.5) * spread * heightSpread;
+
+    positions[i * 3] = tempPosition.x;
+    positions[i * 3 + 1] = tempPosition.y;
+    positions[i * 3 + 2] = tempPosition.z;
+
+    flows[i * 3] = (Math.random() - 0.5) * 2.0;
+    flows[i * 3 + 1] = Math.random();
+    flows[i * 3 + 2] = (Math.random() - 0.5) * 2.0;
+
+    scales[i] = 0.5 + Math.random();
+    seeds[i] = Math.random();
+  }
+
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setAttribute('aFlow', new THREE.Float32BufferAttribute(flows, 3));
+  geometry.setAttribute('aScale', new THREE.Float32BufferAttribute(scales, 1));
+  geometry.setAttribute('aSeed', new THREE.Float32BufferAttribute(seeds, 1));
+
+  mesh.geometry.dispose();
+
+  return geometry;
+}
+
+function buildSmokeGeometry(
+  shape: FireShape,
+  count: number,
+  spread: number,
+): THREE.BufferGeometry<THREE.NormalBufferAttributes> {
+  const mesh = createShapeMesh(shape);
+  const sampler = new MeshSurfaceSampler(mesh).build();
+  const geometry = new THREE.BufferGeometry();
+
+  const positions = new Float32Array(count * 3);
+  const flows = new Float32Array(count * 3);
+  const scales = new Float32Array(count);
+  const seeds = new Float32Array(count);
+
+  const tempPosition = new THREE.Vector3();
+  const tempNormal = new THREE.Vector3();
+
+  let generated = 0;
+  while (generated < count) {
+    sampler.sample(tempPosition, tempNormal);
+    if (tempNormal.y < -0.1 && Math.random() > 0.2) {
+      continue;
+    }
+
+    const offset = spread * (0.2 + Math.random() * 0.8);
+    tempPosition.addScaledVector(tempNormal, offset * 0.5 + Math.abs(tempNormal.y) * spread);
+    tempPosition.x += (Math.random() - 0.5) * spread * 0.7;
+    tempPosition.z += (Math.random() - 0.5) * spread * 0.7;
+    tempPosition.y += offset * 0.5;
+
+    positions[generated * 3] = tempPosition.x;
+    positions[generated * 3 + 1] = tempPosition.y;
+    positions[generated * 3 + 2] = tempPosition.z;
+
+    flows[generated * 3] = (Math.random() - 0.5) * 1.2;
+    flows[generated * 3 + 1] = Math.random();
+    flows[generated * 3 + 2] = (Math.random() - 0.5) * 1.2;
+
+    scales[generated] = 0.6 + Math.random() * 0.8;
+    seeds[generated] = Math.random();
+
+    generated += 1;
+  }
+
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setAttribute('aFlow', new THREE.Float32BufferAttribute(flows, 3));
+  geometry.setAttribute('aScale', new THREE.Float32BufferAttribute(scales, 1));
+  geometry.setAttribute('aSeed', new THREE.Float32BufferAttribute(seeds, 1));
+
+  mesh.geometry.dispose();
+
+  return geometry;
+}
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      fireParticlesMaterial: Object3DNode<FireParticlesMaterialType, typeof FireParticlesMaterial>;
+      smokeParticlesMaterial: Object3DNode<SmokeParticlesMaterialType, typeof SmokeParticlesMaterial>;
+    }
+  }
+}
+
+export function VolumetricFire({
+  shape,
+  flameCount = 1600,
+  smokeCount = 600,
+  spread = 1.1,
+  heightSpread = 0.7,
+  flameControls,
+  smokeControls,
+  ...groupProps
+}: VolumetricFireProps) {
+  const flameGeometry = useMemo(
+    () => buildParticleGeometry(shape, flameCount, spread, heightSpread),
+    [shape, flameCount, spread, heightSpread],
+  );
+
+  const smokeGeometry = useMemo(() => {
+    if (!smokeControls?.enabled || smokeCount <= 0) {
+      return null;
+    }
+    return buildSmokeGeometry(shape, smokeCount, spread * 0.9);
+  }, [shape, smokeControls?.enabled, smokeCount, spread]);
+
+  const flameMaterialRef = useRef<FireMaterialInstance>(null);
+  const smokeMaterialRef = useRef<SmokeMaterialInstance>(null);
+
+  useFrame(({ clock }) => {
+    if (flameMaterialRef.current) {
+      flameMaterialRef.current.uTime = clock.elapsedTime;
+    }
+    if (smokeMaterialRef.current) {
+      smokeMaterialRef.current.uTime = clock.elapsedTime;
+    }
+  });
+
+  useEffect(() => () => flameGeometry.dispose(), [flameGeometry]);
+  useEffect(() => () => smokeGeometry?.dispose(), [smokeGeometry]);
+
+  useEffect(() => {
+    if (!flameMaterialRef.current) {
+      return;
+    }
+    const material = flameMaterialRef.current;
+    material.transparent = true;
+    material.depthWrite = false;
+    material.blending = THREE.AdditiveBlending;
+    material.side = THREE.DoubleSide;
+  }, []);
+
+  useEffect(() => {
+    if (!smokeMaterialRef.current) {
+      return;
+    }
+    const material = smokeMaterialRef.current;
+    material.transparent = true;
+    material.depthWrite = false;
+    material.blending = THREE.NormalBlending;
+    material.side = THREE.DoubleSide;
+  }, [smokeGeometry]);
+
+  useEffect(() => {
+    if (!flameMaterialRef.current) {
+      return;
+    }
+    const material = flameMaterialRef.current;
+    material.uSpeed = flameControls.speed;
+    material.uRise = flameControls.rise;
+    material.uSize = flameControls.size;
+    material.uDistortion = flameControls.distortion;
+    material.uFlowStrength = flameControls.flow;
+    material.uIntensity = flameControls.intensity;
+    material.uFlickerStrength = flameControls.flicker;
+    material.uOpacity = flameControls.opacity;
+    material.uNoiseScale = flameControls.noiseScale;
+    material.uColorInner = new THREE.Color(flameControls.innerColor);
+    material.uColorOuter = new THREE.Color(flameControls.outerColor);
+  }, [flameControls]);
+
+  useEffect(() => {
+    if (!smokeMaterialRef.current || !smokeControls) {
+      return;
+    }
+    const material = smokeMaterialRef.current;
+    material.uSpeed = smokeControls.speed;
+    material.uRise = smokeControls.rise;
+    material.uSize = smokeControls.size;
+    material.uOpacity = smokeControls.opacity;
+    material.uNoiseScale = smokeControls.noiseScale;
+    material.uDrift = smokeControls.drift;
+    material.uColor = new THREE.Color(smokeControls.color);
+  }, [smokeControls]);
+
+  return (
+    <group {...groupProps}>
+      <points
+        geometry={flameGeometry}
+        frustumCulled={false}
+        renderOrder={2}
+      >
+        <fireParticlesMaterial ref={flameMaterialRef} />
+      </points>
+      {smokeGeometry && smokeControls?.enabled ? (
+        <points geometry={smokeGeometry} frustumCulled={false} renderOrder={1}>
+          <smokeParticlesMaterial ref={smokeMaterialRef} />
+        </points>
+      ) : null}
+    </group>
+  );
+}
+
+export type { FireGeometryAttributes };
+

--- a/src/components/three/fire/VolumetricFire.tsx
+++ b/src/components/three/fire/VolumetricFire.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { shaderMaterial } from '@react-three/drei';
-import { extend, type Object3DNode, useFrame } from '@react-three/fiber';
+import { extend, useFrame, type ReactThreeFiber } from '@react-three/fiber';
 import { useEffect, useMemo, useRef } from 'react';
+import type { Ref } from 'react';
 import * as THREE from 'three';
 import { MeshSurfaceSampler } from 'three/examples/jsm/math/MeshSurfaceSampler.js';
 
@@ -288,6 +289,11 @@ type SmokeMaterialInstance = SmokeParticlesMaterialType & {
   uOpacity: number;
 };
 
+type ShaderMaterialElement<T extends THREE.ShaderMaterial> =
+  Omit<ReactThreeFiber.ThreeElements['shaderMaterial'], 'ref'> & {
+    ref?: Ref<T>;
+  };
+
 export type FireShape =
   | { kind: 'plane'; width: number; height: number }
   | { kind: 'sphere'; radius: number }
@@ -327,7 +333,7 @@ export interface SmokeControls {
   color: string;
 }
 
-export interface VolumetricFireProps extends JSX.IntrinsicElements['group'] {
+export type VolumetricFireProps = ReactThreeFiber.ThreeElements['group'] & {
   shape: FireShape;
   flameCount?: number;
   smokeCount?: number;
@@ -335,7 +341,7 @@ export interface VolumetricFireProps extends JSX.IntrinsicElements['group'] {
   heightSpread?: number;
   flameControls: FlameControls;
   smokeControls?: SmokeControls;
-}
+};
 
 type FireGeometryAttributes = {
   position: THREE.BufferAttribute;
@@ -486,12 +492,10 @@ function buildSmokeGeometry(
   return geometry;
 }
 
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      fireParticlesMaterial: Object3DNode<FireParticlesMaterialType, typeof FireParticlesMaterial>;
-      smokeParticlesMaterial: Object3DNode<SmokeParticlesMaterialType, typeof SmokeParticlesMaterial>;
-    }
+declare module '@react-three/fiber' {
+  interface ThreeElements {
+    fireParticlesMaterial: ShaderMaterialElement<FireMaterialInstance>;
+    smokeParticlesMaterial: ShaderMaterialElement<SmokeMaterialInstance>;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated /three-fire page showcasing volumetric flames on several meshes with orbit controls
- implement a reusable VolumetricFire component that uses procedural particle shaders for fire and optional smoke
- expose an on-canvas control panel to tweak flame and smoke behaviour in real time

## Testing
- npm run lint *(fails: biome not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca05175a0c832fa2a08d1051910464