### PR TITLE
Add volumetric fire demo page with reusable R3F components

### DIFF
--- a/src/app/volumetric-fire/page.tsx
+++ b/src/app/volumetric-fire/page.tsx
@@ -1,0 +1,472 @@
+"use client";
+
+import { Suspense, useMemo, useState, type ChangeEvent } from "react";
+import { Canvas } from "@react-three/fiber";
+import { Html, OrbitControls } from "@react-three/drei";
+import { DoubleSide } from "three";
+
+import { VolumetricFire } from "@/components/three/VolumetricFire";
+import { SmokePlume } from "@/components/three/SmokePlume";
+
+type FireConfig = {
+  noiseX: number;
+  noiseY: number;
+  noiseZ: number;
+  speed: number;
+  magnitude: number;
+  lacunarity: number;
+  gain: number;
+  intensity: number;
+  color: string;
+  smoke: number;
+};
+
+const defaultConfig: FireConfig = {
+  noiseX: 1.0,
+  noiseY: 2.6,
+  noiseZ: 1.0,
+  speed: 0.42,
+  magnitude: 1.45,
+  lacunarity: 2.15,
+  gain: 0.48,
+  intensity: 2.35,
+  color: "#ffb567",
+  smoke: 0.6,
+};
+
+type NumericKey = Exclude<keyof FireConfig, "color">;
+
+const toNoiseScale = (config: FireConfig) =>
+  [config.noiseX, config.noiseY, config.noiseZ, config.speed] as [
+    number,
+    number,
+    number,
+    number,
+  ];
+
+function ControlPanel({
+  config,
+  onChange,
+}: {
+  config: FireConfig;
+  onChange: (partial: Partial<FireConfig>) => void;
+}) {
+  const handleRangeChange = (key: NumericKey) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onChange({ [key]: Number.parseFloat(event.currentTarget.value) } as Partial<FireConfig>);
+    };
+
+  const range = (
+    label: string,
+    key: NumericKey,
+    min: number,
+    max: number,
+    step: number,
+    formatter: (value: number) => string = (value) => value.toFixed(2),
+  ) => (
+    <label key={key} className="block space-y-1">
+      <div className="flex items-center justify-between text-xs uppercase tracking-wide text-gray-300">
+        <span>{label}</span>
+        <span className="font-semibold text-gray-100">{formatter(config[key])}</span>
+      </div>
+      <input
+        className="w-full cursor-pointer accent-orange-500"
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={config[key]}
+        onChange={handleRangeChange(key)}
+      />
+    </label>
+  );
+
+  return (
+    <div className="pointer-events-none absolute inset-0 flex justify-end p-6">
+      <div className="pointer-events-auto w-72 rounded-xl bg-black/70 p-4 text-gray-100 shadow-xl backdrop-blur">
+        <h2 className="text-lg font-semibold text-white">Fire Controls</h2>
+        <p className="mt-1 text-xs text-gray-300">
+          Tweak the turbulence, speed, and intensity of the volumetric flames.
+        </p>
+        <div className="mt-4 space-y-3">
+          {range("Rise Speed", "speed", 0.1, 1.0, 0.01, (value) => value.toFixed(2))}
+          {range("Noise Stretch X", "noiseX", 0.4, 2.0, 0.01)}
+          {range("Noise Stretch Y", "noiseY", 0.8, 4.0, 0.05)}
+          {range("Noise Stretch Z", "noiseZ", 0.4, 2.0, 0.01)}
+          {range("Turbulence Magnitude", "magnitude", 0.6, 2.5, 0.01)}
+          {range("Lacunarity", "lacunarity", 1.2, 3.2, 0.01)}
+          {range("Gain", "gain", 0.25, 0.9, 0.01)}
+          {range("Brightness", "intensity", 0.5, 3.5, 0.01)}
+          {range("Smoke Density", "smoke", 0.0, 1.0, 0.01, (value) => value.toFixed(2))}
+        </div>
+        <label className="mt-4 block text-xs uppercase tracking-wide text-gray-300">
+          Flame Palette
+          <input
+            type="color"
+            value={config.color}
+            onChange={(event) => onChange({ color: event.currentTarget.value })}
+            className="mt-1 h-9 w-full cursor-pointer rounded border border-white/20 bg-transparent"
+          />
+        </label>
+      </div>
+    </div>
+  );
+}
+
+interface BurningProps {
+  config: FireConfig;
+  noiseScale: [number, number, number, number];
+  smokeOpacity: number;
+  smokeRise: number;
+}
+
+function BurningPlane({ config, noiseScale, smokeOpacity, smokeRise }: BurningProps) {
+  const frameWidth = 6.2;
+  const frameHeight = 4.2;
+
+  return (
+    <group position={[-15, 2.3, -5]} rotation={[0, Math.PI / 9, 0]}>
+      <mesh castShadow receiveShadow>
+        <planeGeometry args={[frameWidth, frameHeight]} />
+        <meshStandardMaterial
+          color="#1d1d21"
+          metalness={0.15}
+          roughness={0.85}
+          side={DoubleSide}
+        />
+      </mesh>
+      <VolumetricFire
+        size={[frameWidth * 1.05, frameHeight * 1.1, 0.9]}
+        shape="plane"
+        shapeParams={[0.12, 0, 0.35, 0]}
+        noiseScale={noiseScale}
+        magnitude={config.magnitude}
+        lacunarity={config.lacunarity}
+        gain={config.gain}
+        intensity={config.intensity}
+        color={config.color}
+      />
+      <SmokePlume
+        position={[0, frameHeight * 0.55, 0]}
+        spread={2.5}
+        height={5.2}
+        riseSpeed={smokeRise}
+        opacity={smokeOpacity * 0.9}
+        size={60}
+        curlStrength={0.45}
+        color="#b9bec9"
+      />
+      <Html
+        position={[0, -frameHeight * 0.6, 0]}
+        center
+        className="rounded-full bg-black/70 px-3 py-1 text-xs font-medium text-gray-200 shadow"
+      >
+        Flame Wall
+      </Html>
+    </group>
+  );
+}
+
+function BurningCube({ config, noiseScale, smokeOpacity, smokeRise }: BurningProps) {
+  const cubeSize = 2.2;
+
+  return (
+    <group position={[-7.5, 1.6, 5.6]}>
+      <mesh castShadow receiveShadow scale={[cubeSize, cubeSize, cubeSize]}>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial color="#242830" metalness={0.3} roughness={0.4} />
+      </mesh>
+      <VolumetricFire
+        size={[cubeSize * 1.15, cubeSize * 1.15, cubeSize * 1.15]}
+        shape="box"
+        shapeParams={[1, 1, 0.5, 0]}
+        noiseScale={noiseScale}
+        magnitude={config.magnitude}
+        lacunarity={config.lacunarity}
+        gain={config.gain}
+        intensity={config.intensity}
+        color={config.color}
+      />
+      <SmokePlume
+        position={[0, cubeSize * 0.9, 0]}
+        spread={1.2}
+        height={4.2}
+        riseSpeed={smokeRise}
+        opacity={smokeOpacity}
+        size={44}
+        curlStrength={0.38}
+        color="#bfc4cc"
+      />
+      <Html
+        position={[0, -cubeSize * 1.1, 0]}
+        center
+        className="rounded-full bg-black/70 px-3 py-1 text-xs font-medium text-gray-200 shadow"
+      >
+        Cube
+      </Html>
+    </group>
+  );
+}
+
+function BurningCylinder({ config, noiseScale, smokeOpacity, smokeRise }: BurningProps) {
+  const radius = 1.3;
+  const height = 3.4;
+
+  return (
+    <group position={[0, height * 0.42, -6.3]}>
+      <mesh castShadow receiveShadow>
+        <cylinderGeometry args={[radius, radius, height, 64]} />
+        <meshStandardMaterial color="#20242b" metalness={0.25} roughness={0.5} />
+      </mesh>
+      <VolumetricFire
+        size={[radius * 2.4, height * 1.05, radius * 2.4]}
+        shape="cylinder"
+        shapeParams={[0.95, 1.05, 0.4, 0]}
+        noiseScale={noiseScale}
+        magnitude={config.magnitude}
+        lacunarity={config.lacunarity}
+        gain={config.gain}
+        intensity={config.intensity}
+        color={config.color}
+      />
+      <SmokePlume
+        position={[0, height * 0.6, 0]}
+        spread={1.5}
+        height={5.0}
+        riseSpeed={smokeRise * 1.05}
+        opacity={smokeOpacity * 1.05}
+        size={55}
+        curlStrength={0.42}
+        color="#c6cad1"
+      />
+      <Html
+        position={[0, -height * 0.65, 0]}
+        center
+        className="rounded-full bg-black/70 px-3 py-1 text-xs font-medium text-gray-200 shadow"
+      >
+        Cylinder
+      </Html>
+    </group>
+  );
+}
+
+function BurningSphere({ config, noiseScale, smokeOpacity, smokeRise }: BurningProps) {
+  const radius = 1.4;
+
+  return (
+    <group position={[7.8, radius * 0.95, 4.8]}>
+      <mesh castShadow receiveShadow>
+        <sphereGeometry args={[radius, 64, 32]} />
+        <meshStandardMaterial color="#1f242b" metalness={0.2} roughness={0.45} />
+      </mesh>
+      <VolumetricFire
+        size={[radius * 2.4, radius * 2.4, radius * 2.4]}
+        shape="sphere"
+        shapeParams={[0.98, 0, 0.45, 0]}
+        noiseScale={noiseScale}
+        magnitude={config.magnitude}
+        lacunarity={config.lacunarity}
+        gain={config.gain}
+        intensity={config.intensity}
+        color={config.color}
+      />
+      <SmokePlume
+        position={[0, radius * 1.4, 0]}
+        spread={1.6}
+        height={4.4}
+        riseSpeed={smokeRise * 1.1}
+        opacity={smokeOpacity * 0.85}
+        size={48}
+        curlStrength={0.4}
+        color="#c3c8cf"
+      />
+      <Html
+        position={[0, -radius * 1.4, 0]}
+        center
+        className="rounded-full bg-black/70 px-3 py-1 text-xs font-medium text-gray-200 shadow"
+      >
+        Sphere
+      </Html>
+    </group>
+  );
+}
+
+function BurningTorus({ config, noiseScale, smokeOpacity, smokeRise }: BurningProps) {
+  const major = 1.6;
+  const tube = 0.45;
+
+  return (
+    <group position={[15, 1.8, -2.3]}>
+      <mesh castShadow receiveShadow>
+        <torusGeometry args={[major, tube, 64, 128]} />
+        <meshStandardMaterial color="#232831" metalness={0.28} roughness={0.4} />
+      </mesh>
+      <VolumetricFire
+        size={[major * 2.6, (tube + major * 0.6) * 1.6, major * 2.6]}
+        shape="torus"
+        shapeParams={[0.6, 0.32, 0.3, 0]}
+        noiseScale={noiseScale}
+        magnitude={config.magnitude}
+        lacunarity={config.lacunarity}
+        gain={config.gain}
+        intensity={config.intensity}
+        color={config.color}
+      />
+      <SmokePlume
+        position={[0, tube * 4.0, 0]}
+        spread={2.1}
+        height={4.8}
+        riseSpeed={smokeRise * 0.95}
+        opacity={smokeOpacity * 0.9}
+        size={52}
+        curlStrength={0.48}
+        color="#c0c5cc"
+      />
+      <Html
+        position={[0, -(tube + major * 0.8), 0]}
+        center
+        className="rounded-full bg-black/70 px-3 py-1 text-xs font-medium text-gray-200 shadow"
+      >
+        Torus
+      </Html>
+    </group>
+  );
+}
+
+function Ground() {
+  return (
+    <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.05, 0]} receiveShadow>
+      <planeGeometry args={[160, 160]} />
+      <meshStandardMaterial color="#050608" roughness={0.95} metalness={0.05} />
+    </mesh>
+  );
+}
+
+function FireScene({ config }: { config: FireConfig }) {
+  const noiseScale = useMemo(
+    () => toNoiseScale(config),
+    [config.noiseX, config.noiseY, config.noiseZ, config.speed],
+  );
+  const smokeOpacity = useMemo(() => 0.25 + config.smoke * 0.55, [config.smoke]);
+  const smokeRise = useMemo(() => 2.2 + config.speed * 3.4, [config.speed]);
+
+  return (
+    <>
+      <color attach="background" args={["#050608"]} />
+      <fog attach="fog" args={["#050608", 18, 90]} />
+      <ambientLight intensity={0.28} />
+      <directionalLight
+        position={[16, 18, 12]}
+        intensity={1.4}
+        color="#fff3d1"
+        castShadow
+        shadow-mapSize-width={2048}
+        shadow-mapSize-height={2048}
+      />
+      <directionalLight position={[-18, 12, -16]} intensity={0.45} color="#3b4c6a" />
+      <pointLight position={[0, 5.4, 0]} intensity={2.2} distance={48} color={config.color} />
+
+      <Ground />
+
+      <BurningPlane
+        config={config}
+        noiseScale={noiseScale}
+        smokeOpacity={smokeOpacity}
+        smokeRise={smokeRise}
+      />
+      <BurningCube
+        config={config}
+        noiseScale={noiseScale}
+        smokeOpacity={smokeOpacity}
+        smokeRise={smokeRise}
+      />
+      <BurningCylinder
+        config={config}
+        noiseScale={noiseScale}
+        smokeOpacity={smokeOpacity}
+        smokeRise={smokeRise}
+      />
+      <BurningSphere
+        config={config}
+        noiseScale={noiseScale}
+        smokeOpacity={smokeOpacity}
+        smokeRise={smokeRise}
+      />
+      <BurningTorus
+        config={config}
+        noiseScale={noiseScale}
+        smokeOpacity={smokeOpacity}
+        smokeRise={smokeRise}
+      />
+
+      <OrbitControls
+        enableDamping
+        dampingFactor={0.08}
+        minDistance={8}
+        maxDistance={45}
+        target={[0, 1.6, 0]}
+      />
+    </>
+  );
+}
+
+export default function VolumetricFirePage() {
+  const [config, setConfig] = useState<FireConfig>(defaultConfig);
+
+  const handleChange = (partial: Partial<FireConfig>) => {
+    setConfig((prev) => ({ ...prev, ...partial }));
+  };
+
+  return (
+    <div className="min-h-screen bg-black text-white">
+      <div className="relative h-[720px] w-full">
+        <Canvas camera={{ position: [0, 6, 24], fov: 50 }} shadows dpr={[1, 1.5]}>
+          <Suspense fallback={null}>
+            <FireScene config={config} />
+          </Suspense>
+        </Canvas>
+        <ControlPanel config={config} onChange={handleChange} />
+      </div>
+
+      <section className="mx-auto max-w-5xl px-6 py-12">
+        <h1 className="text-4xl font-semibold text-white">Volumetric Fire Playground</h1>
+        <p className="mt-4 text-lg text-gray-300">
+          Explore a modernized volumetric fire shader based on ray-marched turbulence. The scene
+          showcases fire that conforms to drastically different meshes, from thin planes to dense
+          toruses, while orbit controls let you inspect the animation from every angle.
+        </p>
+        <ul className="mt-6 space-y-2 text-gray-300">
+          <li>
+            <span className="font-semibold text-white">Volumetric flames:</span> A ray-marched
+            shader with multi-octave simplex noise feeds a color ramp to produce believable flames
+            that hug the silhouette of each object.
+          </li>
+          <li>
+            <span className="font-semibold text-white">Shape-aware masking:</span> Fire volumes
+            adapt to planes, boxes, spheres, cylinders, and toruses with signed-distance masks so
+            each mesh appears naturally engulfed.
+          </li>
+          <li>
+            <span className="font-semibold text-white">Dynamic smoke:</span> Lightweight point
+            sprites add a curling smoke plume for every piece, matching the configurable burn
+            density.
+          </li>
+          <li>
+            <span className="font-semibold text-white">Live controls:</span> Adjust turbulence,
+            rise speed, color temperature, and brightness with the inline control panel to dial in
+            different fire personalities.
+          </li>
+        </ul>
+        <div className="mt-8">
+          <a
+            href="/"
+            className="inline-flex items-center rounded-full bg-orange-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-orange-500"
+          >
+            ← Back to home
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/src/components/three/SmokePlume.tsx
+++ b/src/components/three/SmokePlume.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { ThreeElements, useFrame, useThree } from "@react-three/fiber";
+import { useEffect, useMemo, useRef } from "react";
+import { Color, PerspectiveCamera, ShaderMaterial } from "three";
+
+const smokeVertexShader = /* glsl */ `
+  precision highp float;
+
+  attribute float shift;
+
+  uniform float time;
+  uniform float riseSpeed;
+  uniform float size;
+  uniform float curlStrength;
+  uniform float projectionScale;
+
+  varying float vFade;
+
+  void main() {
+    float progress = fract(time * riseSpeed * 0.1 + shift);
+    float height = progress * riseSpeed;
+    vec3 displaced = position;
+    displaced.y += height;
+    displaced.x += sin((progress + shift) * 6.28318) * curlStrength * progress;
+    displaced.z += cos((progress + shift) * 6.28318) * curlStrength * progress;
+
+    vFade = 1.0 - progress;
+
+    vec4 mvPosition = modelViewMatrix * vec4(displaced, 1.0);
+    gl_Position = projectionMatrix * mvPosition;
+
+    #ifdef USE_SIZE_ATTENUATION
+      gl_PointSize = size * (1.0 + progress * 0.5) * projectionScale / max(0.0001, gl_Position.w);
+    #else
+      gl_PointSize = size;
+    #endif
+  }
+`;
+
+const smokeFragmentShader = /* glsl */ `
+  precision highp float;
+
+  uniform vec3 smokeColor;
+  uniform float opacity;
+
+  varying float vFade;
+
+  void main() {
+    vec2 coord = gl_PointCoord - 0.5;
+    float dist = length(coord);
+    float alpha = smoothstep(0.5, 0.0, dist) * vFade * opacity;
+
+    if (alpha <= 0.001) {
+      discard;
+    }
+
+    gl_FragColor = vec4(smokeColor, alpha);
+  }
+`;
+
+export interface SmokePlumeProps extends Omit<ThreeElements["points"], "children"> {
+  count?: number;
+  spread?: number;
+  height?: number;
+  size?: number;
+  riseSpeed?: number;
+  curlStrength?: number;
+  opacity?: number;
+  color?: string;
+}
+
+export function SmokePlume({
+  count = 120,
+  spread = 0.8,
+  height = 3.5,
+  size = 40,
+  riseSpeed = 2.4,
+  curlStrength = 0.35,
+  opacity = 0.45,
+  color = "#9ea2a8",
+  ...props
+}: SmokePlumeProps) {
+  const pointsRef = useRef<ThreeElements["points"]["ref"]>(null);
+  const { camera, size: viewport } = useThree();
+
+  const geometry = useMemo(() => {
+    const positions = new Float32Array(count * 3);
+    const shifts = new Float32Array(count);
+
+    for (let i = 0; i < count; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      const radius = Math.random() * spread;
+      const y = Math.random() * height * 0.1;
+
+      positions[i * 3] = Math.cos(angle) * radius;
+      positions[i * 3 + 1] = y;
+      positions[i * 3 + 2] = Math.sin(angle) * radius;
+
+      shifts[i] = Math.random();
+    }
+
+    return { positions, shifts };
+  }, [count, spread, height]);
+
+  const material = useMemo(() => {
+    const shader = new ShaderMaterial({
+      vertexShader: `#define USE_SIZE_ATTENUATION\n${smokeVertexShader}`,
+      fragmentShader: smokeFragmentShader,
+      transparent: true,
+      depthWrite: false,
+      uniforms: {
+        time: { value: 0 },
+        riseSpeed: { value: riseSpeed },
+        size: { value: size },
+        curlStrength: { value: curlStrength },
+        projectionScale: { value: 1 },
+        smokeColor: { value: new Color(color) },
+        opacity: { value: opacity },
+      },
+    });
+    return shader;
+  }, [color, curlStrength, opacity, riseSpeed, size]);
+
+  useEffect(() => () => material.dispose(), [material]);
+
+  useEffect(() => {
+    material.uniforms.opacity.value = opacity;
+  }, [material, opacity]);
+
+  useEffect(() => {
+    material.uniforms.curlStrength.value = curlStrength;
+  }, [material, curlStrength]);
+
+  useEffect(() => {
+    material.uniforms.riseSpeed.value = riseSpeed;
+  }, [material, riseSpeed]);
+
+  useEffect(() => {
+    material.uniforms.size.value = size;
+  }, [material, size]);
+
+  useEffect(() => {
+    (material.uniforms.smokeColor.value as Color).set(color);
+  }, [material, color]);
+
+  useEffect(() => {
+    if ((camera as PerspectiveCamera).isPerspectiveCamera) {
+      const perspective = camera as PerspectiveCamera;
+      const perspectiveScale =
+        viewport.height /
+        (2 * Math.tan((perspective.fov * Math.PI) / 360));
+      material.uniforms.projectionScale.value = perspectiveScale;
+    } else {
+      material.uniforms.projectionScale.value = 1;
+    }
+  }, [camera, material, viewport.height]);
+
+  useFrame((state) => {
+    material.uniforms.time.value = state.clock.getElapsedTime();
+  });
+
+  return (
+    <points ref={pointsRef} {...props}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[geometry.positions, 3]} />
+        <bufferAttribute attach="attributes-shift" args={[geometry.shifts, 1]} />
+      </bufferGeometry>
+      <primitive object={material} attach="material" />
+    </points>
+  );
+}
+

--- a/src/components/three/VolumetricFire.tsx
+++ b/src/components/three/VolumetricFire.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { ThreeElements, useFrame } from "@react-three/fiber";
+import { useEffect, useMemo, useRef } from "react";
+import { Color, Matrix4, Mesh, ShaderMaterial, Vector3, Vector4 } from "three";
+
+import { createFireMaterial, FireShape } from "./volumetricFireMaterial";
+
+const worldMatrix = new Matrix4();
+const worldScale = new Vector3();
+
+export interface VolumetricFireProps
+  extends Omit<ThreeElements["mesh"], "scale"> {
+  size?: [number, number, number];
+  shape?: FireShape;
+  shapeParams?: [number, number, number, number?];
+  color?: string;
+  noiseScale?: [number, number, number, number];
+  magnitude?: number;
+  lacunarity?: number;
+  gain?: number;
+  intensity?: number;
+}
+
+const shapeToIndex: Record<FireShape, number> = {
+  box: 0,
+  sphere: 1,
+  plane: 2,
+  torus: 3,
+  cylinder: 4,
+};
+
+export function VolumetricFire({
+  size = [1, 1, 1],
+  shape = "box",
+  shapeParams = [1, 1, 0.4, 0],
+  color = "#ffffff",
+  noiseScale = [1, 2, 1, 0.35],
+  magnitude = 1.35,
+  lacunarity = 2.0,
+  gain = 0.5,
+  intensity = 1.5,
+  ...props
+}: VolumetricFireProps) {
+  const meshRef = useRef<Mesh | null>(null);
+  const material = useMemo(() => createFireMaterial(), []);
+
+  useEffect(() => () => material.dispose(), [material]);
+
+  useEffect(() => {
+    (material.uniforms.baseColor.value as Color).set(color as string);
+  }, [material, color]);
+
+  useEffect(() => {
+    const [x, y, z, w = 0] = shapeParams;
+    const uniform = material.uniforms.shapeParams.value as Vector4;
+    uniform.set(x, y, z, w);
+  }, [material, shapeParams]);
+
+  useEffect(() => {
+    const [x, y, z, w] = noiseScale;
+    const uniform = material.uniforms.noiseScale.value as Vector4;
+    uniform.set(x, y, z, w);
+  }, [material, noiseScale]);
+
+  useEffect(() => {
+    material.uniforms.magnitude.value = magnitude;
+  }, [material, magnitude]);
+
+  useEffect(() => {
+    material.uniforms.lacunarity.value = lacunarity;
+  }, [material, lacunarity]);
+
+  useEffect(() => {
+    material.uniforms.gain.value = gain;
+  }, [material, gain]);
+
+  useEffect(() => {
+    material.uniforms.intensity.value = intensity;
+  }, [material, intensity]);
+
+  useEffect(() => {
+    material.uniforms.shapeType.value = shapeToIndex[shape];
+  }, [material, shape]);
+
+  useFrame((state) => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+
+    mesh.updateMatrixWorld();
+    worldMatrix.copy(mesh.matrixWorld).invert();
+    worldScale.set(1, 1, 1);
+    mesh.getWorldScale(worldScale);
+
+    (material.uniforms.invModelMatrix.value as Matrix4).copy(worldMatrix);
+    (material.uniforms.scale.value as Vector3).copy(worldScale);
+    material.uniforms.time.value = state.clock.getElapsedTime();
+  });
+
+  return (
+    <mesh ref={meshRef} scale={size} frustumCulled={false} {...props}>
+      <boxGeometry args={[1, 1, 1]} />
+      <primitive object={material as ShaderMaterial} attach="material" />
+    </mesh>
+  );
+}
+

--- a/src/components/three/volumetricFireMaterial.ts
+++ b/src/components/three/volumetricFireMaterial.ts
@@ -1,0 +1,351 @@
+import {
+  AdditiveBlending,
+  ClampToEdgeWrapping,
+  Color,
+  DataTexture,
+  DoubleSide,
+  LinearFilter,
+  Matrix4,
+  RGBAFormat,
+  ShaderMaterial,
+  SRGBColorSpace,
+  Vector3,
+  Vector4,
+} from "three";
+
+const fireVertexShader = /* glsl */ `
+  varying vec3 vWorldPos;
+
+  void main() {
+    vWorldPos = (modelMatrix * vec4(position, 1.0)).xyz;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const fireFragmentShader = /* glsl */ `
+  precision highp float;
+
+  uniform vec3 baseColor;
+  uniform float intensity;
+  uniform float time;
+  uniform float seed;
+  uniform mat4 invModelMatrix;
+  uniform vec3 scale;
+  uniform vec4 noiseScale;
+  uniform float magnitude;
+  uniform float lacunarity;
+  uniform float gain;
+  uniform sampler2D fireTex;
+  uniform int shapeType;
+  uniform vec4 shapeParams;
+
+  varying vec3 vWorldPos;
+
+  float saturate(float value) {
+    return clamp(value, 0.0, 1.0);
+  }
+
+  vec3 toLocal(vec3 p) {
+    return (invModelMatrix * vec4(p, 1.0)).xyz;
+  }
+
+  vec3 safeScale(vec3 s) {
+    return max(s, vec3(0.0001));
+  }
+
+  // Simplex noise helpers from ashima/webgl-noise
+  vec3 mod289(vec3 x) {
+    return x - floor(x * (1.0 / 289.0)) * 289.0;
+  }
+
+  vec4 mod289(vec4 x) {
+    return x - floor(x * (1.0 / 289.0)) * 289.0;
+  }
+
+  vec4 permute(vec4 x) {
+    return mod289(((x * 34.0) + 1.0) * x);
+  }
+
+  vec4 taylorInvSqrt(vec4 r) {
+    return 1.79284291400159 - 0.85373472095314 * r;
+  }
+
+  float snoise(vec3 v) {
+    const vec2 C = vec2(1.0 / 6.0, 1.0 / 3.0);
+    const vec4 D = vec4(0.0, 0.5, 1.0, 2.0);
+
+    vec3 i = floor(v + dot(v, C.yyy));
+    vec3 x0 = v - i + dot(i, C.xxx);
+
+    vec3 g = step(x0.yzx, x0.xyz);
+    vec3 l = 1.0 - g;
+    vec3 i1 = min(g.xyz, l.zxy);
+    vec3 i2 = max(g.xyz, l.zxy);
+
+    vec3 x1 = x0 - i1 + C.xxx;
+    vec3 x2 = x0 - i2 + C.yyy;
+    vec3 x3 = x0 - D.yyy;
+
+    i = mod289(i);
+    vec4 p = permute(
+      permute(
+        permute(
+          i.z + vec4(0.0, i1.z, i2.z, 1.0)
+        ) + i.y + vec4(0.0, i1.y, i2.y, 1.0)
+      ) + i.x + vec4(0.0, i1.x, i2.x, 1.0)
+    );
+
+    float n_ = 0.142857142857;
+    vec3 ns = n_ * D.wyz - D.xzx;
+
+    vec4 j = p - 49.0 * floor(p * ns.z * ns.z);
+
+    vec4 x_ = floor(j * ns.z);
+    vec4 y_ = floor(j - 7.0 * x_);
+
+    vec4 x = x_ * ns.x + ns.yyyy;
+    vec4 y = y_ * ns.x + ns.yyyy;
+    vec4 h = 1.0 - abs(x) - abs(y);
+
+    vec4 b0 = vec4(x.xy, y.xy);
+    vec4 b1 = vec4(x.zw, y.zw);
+
+    vec4 s0 = floor(b0) * 2.0 + 1.0;
+    vec4 s1 = floor(b1) * 2.0 + 1.0;
+    vec4 sh = -step(h, vec4(0.0));
+
+    vec4 a0 = b0.xzyw + s0.xzyw * sh.xxyy;
+    vec4 a1 = b1.xzyw + s1.xzyw * sh.zzww;
+
+    vec3 p0 = vec3(a0.xy, h.x);
+    vec3 p1 = vec3(a0.zw, h.y);
+    vec3 p2 = vec3(a1.xy, h.z);
+    vec3 p3 = vec3(a1.zw, h.w);
+
+    vec4 norm = taylorInvSqrt(vec4(dot(p0, p0), dot(p1, p1), dot(p2, p2), dot(p3, p3)));
+    p0 *= norm.x;
+    p1 *= norm.y;
+    p2 *= norm.z;
+    p3 *= norm.w;
+
+    vec4 m = max(0.6 - vec4(dot(x0, x0), dot(x1, x1), dot(x2, x2), dot(x3, x3)), 0.0);
+    m = m * m;
+
+    return 42.0 * dot(m * m, vec4(dot(p0, x0), dot(p1, x1), dot(p2, x2), dot(p3, x3)));
+  }
+
+  float turbulence(vec3 p) {
+    float sum = 0.0;
+    float freq = 1.0;
+    float amp = 1.0;
+
+    for (int i = 0; i < OCTIVES; i++) {
+      sum += abs(snoise(p * freq)) * amp;
+      freq *= lacunarity;
+      amp *= gain;
+    }
+
+    return sum;
+  }
+
+  float shapeMask(vec3 localPos, vec3 normalized) {
+    vec3 p = normalized * 2.0 - 1.0;
+    float softness = max(shapeParams.z, 0.0001);
+    float dist;
+
+    if (shapeType == 1) {
+      float radius = max(shapeParams.x, 0.0001);
+      dist = length(p) - radius;
+    } else if (shapeType == 2) {
+      float halfThickness = max(shapeParams.x, 0.0001);
+      dist = abs(p.y) - halfThickness;
+    } else if (shapeType == 3) {
+      float major = max(shapeParams.x, 0.0001);
+      float minor = max(shapeParams.y, 0.0001);
+      vec2 q = vec2(length(p.xz) - major, p.y);
+      dist = length(q) - minor;
+    } else if (shapeType == 4) {
+      float radius = max(shapeParams.x, 0.0001);
+      float halfHeight = max(shapeParams.y, 0.0001);
+      vec2 d = vec2(length(p.xz) - radius, abs(p.y) - halfHeight);
+      dist = min(max(d.x, d.y), 0.0) + length(max(d, 0.0));
+    } else {
+      vec3 b = vec3(1.0);
+      vec3 d = abs(p) - b;
+      dist = length(max(d, 0.0)) + min(max(d.x, max(d.y, d.z)), 0.0);
+    }
+
+    return saturate(1.0 - smoothstep(0.0, softness, dist));
+  }
+
+  vec2 computeProfileUV(vec3 localPos, vec3 normalized, vec3 s) {
+    float radius;
+
+    if (shapeType == 1) {
+      float maxAxis = max(s.x, max(s.y, s.z));
+      radius = clamp(length(localPos) / max(0.0001, 0.5 * maxAxis), 0.0, 1.0);
+    } else if (shapeType == 3) {
+      vec3 p = normalized * 2.0 - 1.0;
+      float major = max(shapeParams.x, 0.0001);
+      float minor = max(shapeParams.y, 0.0001);
+      vec2 q = vec2(length(p.xz) - major, p.y);
+      radius = clamp(length(q) / minor, 0.0, 1.0);
+    } else {
+      float denom = max(max(s.x, s.z), 0.0001);
+      radius = clamp(length(localPos.xz) / (0.5 * denom), 0.0, 1.0);
+    }
+
+    float height = clamp(normalized.y, 0.0, 1.0);
+    return vec2(radius, height);
+  }
+
+  void main() {
+    vec3 rayPos = vWorldPos;
+    vec3 rayDir = normalize(rayPos - cameraPosition);
+    vec3 s = safeScale(scale);
+    float stepSize = 0.03 * length(s);
+
+    vec4 col = vec4(0.0);
+
+    for (int i = 0; i < ITERATIONS; i++) {
+      rayPos += rayDir * stepSize;
+      vec3 localPos = toLocal(rayPos);
+      vec3 normalized = localPos / s + 0.5;
+
+      if (any(lessThan(normalized, vec3(0.0))) || any(greaterThan(normalized, vec3(1.0)))) {
+        continue;
+      }
+
+      float mask = shapeMask(localPos, normalized);
+      if (mask <= 0.0001) {
+        continue;
+      }
+
+      vec3 noisePoint = localPos;
+      noisePoint.y -= (seed + time) * noiseScale.w;
+      noisePoint *= noiseScale.xyz;
+
+      float turb = turbulence(noisePoint);
+      float height = clamp(normalized.y + pow(normalized.y, 0.5) * magnitude * turb, 0.0, 1.0);
+
+      vec2 st = computeProfileUV(localPos, normalized, s);
+      st.y = height;
+
+      if (st.y <= 0.0 || st.y >= 1.0) {
+        continue;
+      }
+
+      vec4 sampleCol = texture2D(fireTex, st);
+      sampleCol.rgb *= mask;
+      sampleCol.a *= mask;
+
+      col.rgb += sampleCol.rgb * sampleCol.a;
+      col.a += sampleCol.a;
+    }
+
+    col.rgb *= baseColor * intensity;
+    col.a = saturate(col.a * intensity);
+
+    if (col.a <= 0.0001) {
+      discard;
+    }
+
+    gl_FragColor = vec4(col.rgb, col.a);
+  }
+`;
+
+const fireTexture = (() => {
+  const saturateScalar = (value: number) => Math.min(Math.max(value, 0), 1);
+
+  const width = 16;
+  const height = 256;
+  const data = new Uint8Array(width * height * 4);
+
+  const gradientStops = [
+    { pos: 0.0, color: new Color(0x050505) },
+    { pos: 0.08, color: new Color(0x2b0500) },
+    { pos: 0.18, color: new Color(0x7a1100) },
+    { pos: 0.32, color: new Color(0xf44800) },
+    { pos: 0.5, color: new Color(0xffa000) },
+    { pos: 0.7, color: new Color(0xffe08c) },
+    { pos: 1.0, color: new Color(0xffffff) },
+  ];
+
+  const lerpColor = (t: number) => {
+    let lower = gradientStops[0];
+    let upper = gradientStops[gradientStops.length - 1];
+
+    for (let i = 0; i < gradientStops.length - 1; i++) {
+      const a = gradientStops[i];
+      const b = gradientStops[i + 1];
+      if (t >= a.pos && t <= b.pos) {
+        lower = a;
+        upper = b;
+        break;
+      }
+    }
+
+    const span = upper.pos - lower.pos || 1;
+    const localT = (t - lower.pos) / span;
+    const color = lower.color.clone().lerp(upper.color, localT);
+    return color;
+  };
+
+  for (let y = 0; y < height; y++) {
+    const t = y / (height - 1);
+    const color = lerpColor(t);
+    const alpha = Math.pow(saturateScalar(t), 1.5);
+
+    for (let x = 0; x < width; x++) {
+      const index = (y * width + x) * 4;
+      data[index] = Math.floor(color.r * 255);
+      data[index + 1] = Math.floor(color.g * 255);
+      data[index + 2] = Math.floor(color.b * 255);
+      data[index + 3] = Math.floor(alpha * 255);
+    }
+  }
+
+  const texture = new DataTexture(data, width, height, RGBAFormat);
+  texture.magFilter = LinearFilter;
+  texture.minFilter = LinearFilter;
+  texture.wrapS = ClampToEdgeWrapping;
+  texture.wrapT = ClampToEdgeWrapping;
+  texture.colorSpace = SRGBColorSpace;
+  texture.needsUpdate = true;
+  return texture;
+})();
+
+export const createFireMaterial = () => {
+  const material = new ShaderMaterial({
+    defines: {
+      ITERATIONS: "48",
+      OCTIVES: "4",
+    },
+    uniforms: {
+      fireTex: { value: fireTexture },
+      baseColor: { value: new Color(0xffffff) },
+      intensity: { value: 1.5 },
+      time: { value: 0 },
+      seed: { value: Math.random() * 19.19 },
+      invModelMatrix: { value: new Matrix4() },
+      scale: { value: new Vector3(1, 1, 1) },
+      noiseScale: { value: new Vector4(1, 2, 1, 0.35) },
+      magnitude: { value: 1.35 },
+      lacunarity: { value: 2.0 },
+      gain: { value: 0.5 },
+      shapeType: { value: 0 },
+      shapeParams: { value: new Vector4(1, 1, 0.4, 0) },
+    },
+    vertexShader: fireVertexShader,
+    fragmentShader: fireFragmentShader,
+    transparent: true,
+    depthWrite: false,
+    blending: AdditiveBlending,
+    side: DoubleSide,
+  });
+
+  return material;
+};
+
+export type FireShape = "box" | "sphere" | "plane" | "torus" | "cylinder";
+


### PR DESCRIPTION
## Summary
- implement a reusable volumetric fire shader that ray-marches simplex noise and masks to different shapes
- add VolumetricFire and SmokePlume React Three Fiber components for fire and smoke attachments
- create a /volumetric-fire Next.js page showcasing multiple burning shapes with configurable controls

## Testing
- CI=true npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca20edbbec832f9c550ff140317065