### PR TITLE
Add Grass v3 demo with instanced grass field

### DIFF
--- a/src/app/grass-v3/page.tsx
+++ b/src/app/grass-v3/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const GrassV3Demo = dynamic(() => import("@/components/grassv3/GrassV3Demo"), {
+  ssr: false,
+});
+
+export default function GrassV3Page() {
+  return (
+    <div className="fixed inset-0 bg-gray-900">
+      <GrassV3Demo />
+    </div>
+  );
+}

--- a/src/components/grassv3/GrassField.tsx
+++ b/src/components/grassv3/GrassField.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useCallback, useMemo, useRef, type MutableRefObject } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+import type { HeightmapData } from "./heightmap";
+import { createGrassGeometry } from "./geometry";
+import { GrassV3Material } from "./GrassMaterial";
+
+const NUM_GRASS = (32 * 32) * 3;
+const GRASS_SEGMENTS_LOW = 1;
+const GRASS_SEGMENTS_HIGH = 6;
+const GRASS_VERTICES_LOW = (GRASS_SEGMENTS_LOW + 1) * 2;
+const GRASS_VERTICES_HIGH = (GRASS_SEGMENTS_HIGH + 1) * 2;
+const GRASS_LOD_DIST = 18;
+const GRASS_MAX_DIST = 110;
+const GRASS_PATCH_SIZE = 10;
+const GRASS_WIDTH = 0.1;
+const GRASS_HEIGHT = 1.5;
+const PATCH_RADIUS = 16;
+
+interface GrassFieldProps {
+  heightmap: HeightmapData;
+  playerPosition: MutableRefObject<THREE.Vector3>;
+}
+
+export function GrassField({ heightmap, playerPosition }: GrassFieldProps) {
+  const groupRef = useRef<THREE.Group>(null);
+  const lowMeshes = useRef<THREE.Mesh[]>([]);
+  const highMeshes = useRef<THREE.Mesh[]>([]);
+
+  const geometryLow = useMemo(
+    () =>
+      createGrassGeometry({
+        segments: GRASS_SEGMENTS_LOW,
+        numInstances: NUM_GRASS,
+        patchSize: GRASS_PATCH_SIZE,
+      }),
+    [],
+  );
+
+  const geometryHigh = useMemo(
+    () =>
+      createGrassGeometry({
+        segments: GRASS_SEGMENTS_HIGH,
+        numInstances: NUM_GRASS,
+        patchSize: GRASS_PATCH_SIZE,
+        seed: 4242,
+      }),
+    [],
+  );
+
+  const materialLow = useMemo(() => {
+    const mat = new GrassV3Material({ color: 0xffffff });
+    mat.alphaTest = 0.5;
+    mat.transparent = false;
+    mat.setVec2("grassSize", new THREE.Vector2(GRASS_WIDTH, GRASS_HEIGHT));
+    mat.setVec4(
+      "grassParams",
+      new THREE.Vector4(GRASS_SEGMENTS_LOW, GRASS_VERTICES_LOW, heightmap.height, heightmap.offset),
+    );
+    mat.setVec4("grassDraw", new THREE.Vector4(GRASS_LOD_DIST, GRASS_MAX_DIST, 0, 0));
+    mat.setTexture("heightmap", heightmap.texture);
+    mat.setVec4(
+      "heightParams",
+      new THREE.Vector4(heightmap.dims, heightmap.dims, heightmap.height, heightmap.offset),
+    );
+    mat.setVec3("grassLODColour", new THREE.Vector3(0, 0, 1));
+    return mat;
+  }, [heightmap]);
+
+  const materialHigh = useMemo(() => {
+    const mat = new GrassV3Material({ color: 0xffffff });
+    mat.alphaTest = 0.5;
+    mat.transparent = false;
+    mat.setVec2("grassSize", new THREE.Vector2(GRASS_WIDTH, GRASS_HEIGHT));
+    mat.setVec4(
+      "grassParams",
+      new THREE.Vector4(GRASS_SEGMENTS_HIGH, GRASS_VERTICES_HIGH, heightmap.height, heightmap.offset),
+    );
+    mat.setVec4("grassDraw", new THREE.Vector4(GRASS_LOD_DIST, GRASS_MAX_DIST, 0, 0));
+    mat.setTexture("heightmap", heightmap.texture);
+    mat.setVec4(
+      "heightParams",
+      new THREE.Vector4(heightmap.dims, heightmap.dims, heightmap.height, heightmap.offset),
+    );
+    mat.setVec3("grassLODColour", new THREE.Vector3(1, 0, 0));
+    return mat;
+  }, [heightmap]);
+
+  const frustum = useMemo(() => new THREE.Frustum(), []);
+  const projMatrix = useMemo(() => new THREE.Matrix4(), []);
+  const cameraPosXZ = useMemo(() => new THREE.Vector3(), []);
+  const baseCell = useMemo(() => new THREE.Vector3(), []);
+  const patchCenter = useMemo(() => new THREE.Vector3(), []);
+  const aabb = useMemo(() => new THREE.Box3(), []);
+  const patchSizeVec = useMemo(() => new THREE.Vector3(), []);
+
+  const createMesh = useCallback(
+    (lod: "low" | "high") => {
+      const geo = lod === "low" ? geometryLow : geometryHigh;
+      const mat = lod === "low" ? materialLow : materialHigh;
+      const mesh = new THREE.Mesh(geo, mat);
+      mesh.castShadow = false;
+      mesh.receiveShadow = true;
+      mesh.visible = false;
+      mesh.matrixAutoUpdate = true;
+      if (groupRef.current) {
+        groupRef.current.add(mesh);
+      }
+      if (lod === "low") {
+        lowMeshes.current.push(mesh);
+      } else {
+        highMeshes.current.push(mesh);
+      }
+      return mesh;
+    },
+    [geometryLow, geometryHigh, materialLow, materialHigh],
+  );
+
+  useFrame(({ camera, clock }) => {
+    const time = clock.getElapsedTime();
+    materialLow.setFloat("time", time);
+    materialHigh.setFloat("time", time);
+
+    materialLow.setMatrix("viewMatrixInverse", camera.matrixWorld);
+    materialHigh.setMatrix("viewMatrixInverse", camera.matrixWorld);
+
+    materialLow.setVec3("playerPos", playerPosition.current);
+    materialHigh.setVec3("playerPos", playerPosition.current);
+
+    projMatrix.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse);
+    frustum.setFromProjectionMatrix(projMatrix);
+
+    cameraPosXZ.set(camera.position.x, 0, camera.position.z);
+
+    baseCell.copy(camera.position);
+    baseCell.divideScalar(GRASS_PATCH_SIZE);
+    baseCell.floor();
+    baseCell.multiplyScalar(GRASS_PATCH_SIZE);
+
+    patchSizeVec.set(GRASS_PATCH_SIZE, heightmap.height * 2 + 40, GRASS_PATCH_SIZE);
+
+    for (const mesh of lowMeshes.current) {
+      mesh.visible = false;
+    }
+    for (const mesh of highMeshes.current) {
+      mesh.visible = false;
+    }
+
+    const availableLow = [...lowMeshes.current];
+    const availableHigh = [...highMeshes.current];
+
+    for (let x = -PATCH_RADIUS; x <= PATCH_RADIUS; x++) {
+      for (let z = -PATCH_RADIUS; z <= PATCH_RADIUS; z++) {
+        patchCenter.set(
+          baseCell.x + x * GRASS_PATCH_SIZE,
+          heightmap.getHeight(baseCell.x + x * GRASS_PATCH_SIZE, baseCell.z + z * GRASS_PATCH_SIZE),
+          baseCell.z + z * GRASS_PATCH_SIZE,
+        );
+
+        aabb.setFromCenterAndSize(patchCenter, patchSizeVec);
+        const distToCell = aabb.distanceToPoint(cameraPosXZ);
+        if (distToCell > GRASS_MAX_DIST) {
+          continue;
+        }
+
+        if (!frustum.intersectsBox(aabb)) {
+          continue;
+        }
+
+        let mesh: THREE.Mesh | undefined;
+        if (distToCell > GRASS_LOD_DIST) {
+          mesh = availableLow.pop();
+          if (!mesh) {
+            mesh = createMesh("low") ?? undefined;
+          }
+        } else {
+          mesh = availableHigh.pop();
+          if (!mesh) {
+            mesh = createMesh("high") ?? undefined;
+          }
+        }
+
+        if (!mesh) {
+          continue;
+        }
+
+        mesh.position.set(patchCenter.x, 0, patchCenter.z);
+        mesh.visible = true;
+      }
+    }
+  });
+
+  return <group ref={groupRef} />;
+}

--- a/src/components/grassv3/GrassMaterial.ts
+++ b/src/components/grassv3/GrassMaterial.ts
@@ -1,0 +1,99 @@
+import * as THREE from "three";
+import { GRASS_FRAGMENT_SHADER, GRASS_VERTEX_SHADER, type GrassShader } from "./shaders";
+
+type UniformValue = { value: unknown };
+
+type UniformDictionary = Record<string, UniformValue>;
+
+export class GrassV3Material extends THREE.MeshPhongMaterial {
+  #shader: GrassShader | null = null;
+  #uniforms: UniformDictionary = {};
+
+  constructor(parameters: THREE.MeshPhongMaterialParameters = {}) {
+    super({ color: 0xffffff, side: THREE.FrontSide, ...parameters });
+
+    this.#uniforms = {
+      time: { value: 0 },
+      grassSize: { value: new THREE.Vector2(0.1, 1.0) },
+      grassParams: { value: new THREE.Vector4() },
+      grassDraw: { value: new THREE.Vector4() },
+      heightmap: { value: null },
+      heightParams: { value: new THREE.Vector4() },
+      playerPos: { value: new THREE.Vector3() },
+      viewMatrixInverse: { value: new THREE.Matrix4() },
+      grassLODColour: { value: new THREE.Vector3(0, 0, 0) },
+    };
+
+    this.onBeforeCompile = (shader) => {
+      shader.vertexShader = GRASS_VERTEX_SHADER;
+      shader.fragmentShader = GRASS_FRAGMENT_SHADER;
+      shader.uniforms = {
+        ...shader.uniforms,
+        ...this.#uniforms,
+      };
+      this.#shader = shader;
+    };
+
+    this.customProgramCacheKey = () => {
+      const keys = Object.keys(this.#uniforms).sort();
+      let cacheKey = "GrassV3Material";
+      for (const key of keys) {
+        const uniform = this.#uniforms[key];
+        const value = uniform.value;
+        if (value === null || value === undefined) {
+          cacheKey += `|${key}:null`;
+        } else if (typeof value === "number") {
+          cacheKey += `|${key}:${value}`;
+        } else if (value instanceof THREE.Vector2 || value instanceof THREE.Vector3 || value instanceof THREE.Vector4) {
+          cacheKey += `|${key}:${value.toArray().join(",")}`;
+        } else if (value instanceof THREE.Matrix4) {
+          cacheKey += `|${key}:${value.toArray().join(",")}`;
+        } else if (value instanceof THREE.Texture) {
+          cacheKey += `|${key}:${value.uuid}`;
+        } else {
+          cacheKey += `|${key}:${JSON.stringify(value)}`;
+        }
+      }
+      return cacheKey;
+    };
+  }
+
+  #setUniform(name: string, value: unknown) {
+    if (!this.#uniforms[name]) {
+      this.#uniforms[name] = { value };
+    } else {
+      this.#uniforms[name].value = value;
+    }
+
+    if (this.#shader) {
+      if (!this.#shader.uniforms[name]) {
+        this.#shader.uniforms[name] = this.#uniforms[name];
+      }
+      this.#shader.uniforms[name].value = value;
+    }
+  }
+
+  setFloat(name: string, value: number) {
+    this.#setUniform(name, value);
+  }
+
+  setVec2(name: string, value: THREE.Vector2) {
+    this.#setUniform(name, value);
+  }
+
+  setVec3(name: string, value: THREE.Vector3) {
+    this.#setUniform(name, value);
+  }
+
+  setVec4(name: string, value: THREE.Vector4) {
+    this.#setUniform(name, value);
+  }
+
+  setMatrix(name: string, value: THREE.Matrix4) {
+    this.#setUniform(name, value);
+  }
+
+  setTexture(name: string, value: THREE.Texture | null) {
+    this.#setUniform(name, value);
+  }
+}

--- a/src/components/grassv3/GrassV3Demo.tsx
+++ b/src/components/grassv3/GrassV3Demo.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Environment, OrbitControls, StatsGl } from "@react-three/drei";
+import { Canvas, useFrame } from "@react-three/fiber";
+import { Suspense, useMemo, useRef, type MutableRefObject } from "react";
+import * as THREE from "three";
+import { GrassField } from "./GrassField";
+import { createHeightmapData, type HeightmapData } from "./heightmap";
+
+function Terrain({ heightmap }: { heightmap: HeightmapData }) {
+  const geometry = useMemo(() => {
+    const segments = 256;
+    const geo = new THREE.PlaneGeometry(heightmap.dims, heightmap.dims, segments, segments);
+    geo.rotateX(-Math.PI / 2);
+    const pos = geo.attributes.position as THREE.BufferAttribute;
+    for (let i = 0; i < pos.count; i++) {
+      const x = pos.getX(i);
+      const z = pos.getZ(i);
+      const y = heightmap.getHeight(x, z);
+      pos.setY(i, y);
+    }
+    pos.needsUpdate = true;
+    geo.computeVertexNormals();
+    return geo;
+  }, [heightmap]);
+
+  return (
+    <mesh geometry={geometry} receiveShadow castShadow={false}>
+      <meshStandardMaterial color="#4a6a3b" roughness={0.85} metalness={0.1} />
+    </mesh>
+  );
+}
+
+function PlayerMarker({
+  heightmap,
+  playerPosition,
+}: {
+  heightmap: HeightmapData;
+  playerPosition: MutableRefObject<THREE.Vector3>;
+}) {
+  const markerRef = useRef<THREE.Mesh>(null);
+
+  useFrame(({ clock }) => {
+    const t = clock.getElapsedTime() * 0.25;
+    const radius = heightmap.dims * 0.22;
+    const x = Math.cos(t) * radius;
+    const z = Math.sin(t * 0.8) * radius;
+    const y = heightmap.getHeight(x, z) + 1.8;
+    playerPosition.current.set(x, y, z);
+    if (markerRef.current) {
+      markerRef.current.position.copy(playerPosition.current);
+    }
+  });
+
+  return (
+    <mesh ref={markerRef} castShadow>
+      <sphereGeometry args={[1.5, 32, 32]} />
+      <meshStandardMaterial color="#ffddaa" roughness={0.4} metalness={0.15} />
+    </mesh>
+  );
+}
+
+export default function GrassV3Demo() {
+  const heightmap = useMemo(() => createHeightmapData({ size: 256, dims: 320, height: 18, offset: 9 }), []);
+  const playerPosition = useRef(new THREE.Vector3(0, heightmap.getHeight(0, 0) + 1.8, 0));
+
+  return (
+    <Canvas shadows camera={{ position: [45, 32, 45], fov: 45 }}>
+      <Suspense fallback={null}>
+        <color attach="background" args={["#8fc5ff"]} />
+        <fog attach="fog" args={["#8fc5ff", 80, 260]} />
+        <hemisphereLight intensity={0.6} groundColor="#2f4030" />
+        <directionalLight
+          position={[70, 90, 30]}
+          intensity={1.35}
+          castShadow
+          shadow-mapSize={[2048, 2048]}
+          shadow-camera-near={10}
+          shadow-camera-far={220}
+          shadow-camera-left={-80}
+          shadow-camera-right={80}
+          shadow-camera-top={80}
+          shadow-camera-bottom={-80}
+        />
+
+        <Terrain heightmap={heightmap} />
+        <GrassField heightmap={heightmap} playerPosition={playerPosition} />
+        <PlayerMarker heightmap={heightmap} playerPosition={playerPosition} />
+
+        <Environment preset="sunset" />
+        <OrbitControls makeDefault maxPolarAngle={Math.PI * 0.5} target={[0, 6, 0]} />
+      </Suspense>
+      <StatsGl className="absolute top-0 left-0" />
+    </Canvas>
+  );
+}

--- a/src/components/grassv3/geometry.ts
+++ b/src/components/grassv3/geometry.ts
@@ -1,0 +1,76 @@
+import * as THREE from "three";
+
+function mulberry32(seed: number) {
+  let a = seed;
+  return function random() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function createGrassGeometry({
+  segments,
+  numInstances,
+  patchSize,
+  seed = 42,
+}: {
+  segments: number;
+  numInstances: number;
+  patchSize: number;
+  seed?: number;
+}) {
+  const vertices = (segments + 1) * 2;
+  const indices = new Uint16Array(segments * 12);
+
+  for (let i = 0; i < segments; i++) {
+    const vi = i * 2;
+    const indexOffset = i * 12;
+    indices[indexOffset + 0] = vi + 0;
+    indices[indexOffset + 1] = vi + 1;
+    indices[indexOffset + 2] = vi + 2;
+
+    indices[indexOffset + 3] = vi + 2;
+    indices[indexOffset + 4] = vi + 1;
+    indices[indexOffset + 5] = vi + 3;
+
+    const fi = vertices + vi;
+    indices[indexOffset + 6] = fi + 2;
+    indices[indexOffset + 7] = fi + 1;
+    indices[indexOffset + 8] = fi + 0;
+
+    indices[indexOffset + 9] = fi + 3;
+    indices[indexOffset + 10] = fi + 1;
+    indices[indexOffset + 11] = fi + 2;
+  }
+
+  const vertIndex = new Uint8Array(vertices * 2);
+  for (let i = 0; i < vertIndex.length; i++) {
+    vertIndex[i] = i;
+  }
+
+  const offsets = new Float32Array(numInstances * 3);
+  const random = mulberry32(seed);
+  for (let i = 0; i < numInstances; i++) {
+    const x = (random() - 0.5) * patchSize;
+    const z = (random() - 0.5) * patchSize;
+    offsets[i * 3 + 0] = x;
+    offsets[i * 3 + 1] = 0;
+    offsets[i * 3 + 2] = z;
+  }
+
+  const geometry = new THREE.InstancedBufferGeometry();
+  geometry.instanceCount = numInstances;
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+  geometry.setAttribute("vertIndex", new THREE.Uint8BufferAttribute(vertIndex, 1));
+  geometry.setAttribute("position", new THREE.InstancedBufferAttribute(offsets, 3));
+  geometry.boundingSphere = new THREE.Sphere(new THREE.Vector3(0, 0, 0), 1 + patchSize * 2);
+  geometry.boundingBox = new THREE.Box3(
+    new THREE.Vector3(-patchSize * 0.5, -patchSize, -patchSize * 0.5),
+    new THREE.Vector3(patchSize * 0.5, patchSize, patchSize * 0.5),
+  );
+
+  return geometry;
+}

--- a/src/components/grassv3/heightmap.ts
+++ b/src/components/grassv3/heightmap.ts
@@ -1,0 +1,118 @@
+import * as THREE from "three";
+import { createNoise2D } from "simplex-noise";
+
+export interface HeightmapData {
+  size: number;
+  dims: number;
+  height: number;
+  offset: number;
+  texture: THREE.DataTexture;
+  getHeight: (x: number, z: number) => number;
+}
+
+function mulberry32(seed: number) {
+  let a = seed;
+  return function random() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function createHeightmapData({
+  size = 256,
+  dims = 300,
+  height = 14,
+  offset = height * 0.5,
+  seed = 1337,
+}: {
+  size?: number;
+  dims?: number;
+  height?: number;
+  offset?: number;
+  seed?: number;
+} = {}): HeightmapData {
+  const random = mulberry32(seed);
+  const noise2D = createNoise2D(random);
+  const data = new Float32Array(size * size);
+  const textureData = new Uint8Array(size * size * 4);
+
+  const octaveWeights = [1, 0.5, 0.25, 0.125];
+  let maxWeight = 0;
+  for (const w of octaveWeights) maxWeight += w;
+
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const u = x / size;
+      const v = y / size;
+      let value = 0;
+      let frequency = 1;
+      for (const weight of octaveWeights) {
+        const n = noise2D(u * frequency, v * frequency) * 0.5 + 0.5;
+        value += n * weight;
+        frequency *= 2;
+      }
+      value /= maxWeight;
+      const idx = y * size + x;
+      data[idx] = value;
+      const byte = Math.floor(THREE.MathUtils.clamp(value, 0, 1) * 255);
+      const offsetIdx = idx * 4;
+      textureData[offsetIdx + 0] = byte;
+      textureData[offsetIdx + 1] = byte;
+      textureData[offsetIdx + 2] = byte;
+      textureData[offsetIdx + 3] = 255;
+    }
+  }
+
+  const texture = new THREE.DataTexture(textureData, size, size, THREE.RGBAFormat);
+  texture.needsUpdate = true;
+  texture.magFilter = THREE.LinearFilter;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.generateMipmaps = true;
+  texture.wrapS = THREE.ClampToEdgeWrapping;
+  texture.wrapT = THREE.ClampToEdgeWrapping;
+  texture.colorSpace = THREE.LinearSRGBColorSpace;
+
+  const getHeight = (x: number, z: number) => {
+    const xn = THREE.MathUtils.clamp((x + dims * 0.5) / dims, 0, 1);
+    const zn = THREE.MathUtils.clamp((z + dims * 0.5) / dims, 0, 1);
+
+    const px = xn * (size - 1);
+    const py = (1 - zn) * (size - 1);
+
+    const x1 = Math.floor(px);
+    const x2 = Math.min(x1 + 1, size - 1);
+    const y1 = Math.floor(py);
+    const y2 = Math.min(y1 + 1, size - 1);
+
+    const fx = px - x1;
+    const fy = py - y1;
+
+    const idx11 = y1 * size + x1;
+    const idx12 = y2 * size + x1;
+    const idx21 = y1 * size + x2;
+    const idx22 = y2 * size + x2;
+
+    const v11 = data[idx11];
+    const v21 = data[idx21];
+    const v12 = data[idx12];
+    const v22 = data[idx22];
+
+    const top = THREE.MathUtils.lerp(v11, v21, fx);
+    const bottom = THREE.MathUtils.lerp(v12, v22, fx);
+    const value = THREE.MathUtils.lerp(top, bottom, fy);
+
+    return value * height - offset;
+  };
+
+  return {
+    size,
+    dims,
+    height,
+    offset,
+    texture,
+    getHeight,
+  };
+}

--- a/src/components/grassv3/shaders.ts
+++ b/src/components/grassv3/shaders.ts
@@ -1,5 +1,3 @@
-import { type Shader } from "three";
-
 export const GRASS_VERTEX_SHADER = /* glsl */ `
 #define PHONG
 varying vec3 vViewPosition;
@@ -421,4 +419,8 @@ void main() {
 }
 `;
 
-export type GrassShader = Shader;
+export type GrassShader = {
+  vertexShader: string;
+  fragmentShader: string;
+  uniforms: Record<string, { value: unknown }>;
+};

--- a/src/components/grassv3/shaders.ts
+++ b/src/components/grassv3/shaders.ts
@@ -1,0 +1,424 @@
+import { type Shader } from "three";
+
+export const GRASS_VERTEX_SHADER = /* glsl */ `
+#define PHONG
+varying vec3 vViewPosition;
+#include <common>
+#include <uv_pars_vertex>
+#include <displacementmap_pars_vertex>
+#include <envmap_pars_vertex>
+#include <color_pars_vertex>
+#include <fog_pars_vertex>
+#include <normal_pars_vertex>
+#include <morphtarget_pars_vertex>
+#include <skinning_pars_vertex>
+#include <shadowmap_pars_vertex>
+#include <logdepthbuf_pars_vertex>
+#include <clipping_planes_pars_vertex>
+
+varying vec3 vWorldNormal;
+varying vec3 vGrassColour;
+varying vec4 vGrassParams;
+varying vec3 vNormal2;
+varying vec3 vWorldPosition;
+
+uniform vec2 grassSize;
+uniform vec4 grassParams;
+uniform vec4 grassDraw;
+uniform float time;
+uniform sampler2D heightmap;
+uniform vec4 heightParams;
+uniform vec3 playerPos;
+uniform mat4 viewMatrixInverse;
+
+attribute float vertIndex;
+
+float linearstep(float minValue, float maxValue, float v) {
+  return clamp((v - minValue) / (maxValue - minValue), 0.0, 1.0);
+}
+
+float remap(float v, float inMin, float inMax, float outMin, float outMax) {
+  float t = (v - inMin) / (inMax - inMin);
+  return mix(outMin, outMax, t);
+}
+
+float easeOut(float x, float t) {
+  return 1.0 - pow(1.0 - x, t);
+}
+
+float easeIn(float x, float t) {
+  return pow(x, t);
+}
+
+mat3 rotateX(float theta) {
+  float c = cos(theta);
+  float s = sin(theta);
+  return mat3(
+    vec3(1.0, 0.0, 0.0),
+    vec3(0.0, c, -s),
+    vec3(0.0, s, c)
+  );
+}
+
+mat3 rotateY(float theta) {
+  float c = cos(theta);
+  float s = sin(theta);
+  return mat3(
+    vec3(c, 0.0, s),
+    vec3(0.0, 1.0, 0.0),
+    vec3(-s, 0.0, c)
+  );
+}
+
+mat3 rotateAxis(vec3 axis, float angle) {
+  axis = normalize(axis);
+  float s = sin(angle);
+  float c = cos(angle);
+  float oc = 1.0 - c;
+  return mat3(
+    oc * axis.x * axis.x + c,           oc * axis.x * axis.y - axis.z * s,  oc * axis.z * axis.x + axis.y * s,
+    oc * axis.x * axis.y + axis.z * s,  oc * axis.y * axis.y + c,           oc * axis.y * axis.z - axis.x * s,
+    oc * axis.z * axis.x - axis.y * s,  oc * axis.y * axis.z + axis.x * s,  oc * axis.z * axis.z + c
+  );
+}
+
+float hash12(vec2 p) {
+  vec3 p3 = fract(vec3(p.xyx) * 0.1031);
+  p3 += dot(p3, p3.yzx + 33.33);
+  return fract((p3.x + p3.y) * p3.z);
+}
+
+vec2 hash22(vec2 p) {
+  vec3 p3 = fract(vec3(p.xyx) * vec3(0.1031, 0.1030, 0.0973));
+  p3 += dot(p3, p3.yzx + 33.33);
+  return fract((vec2(p3.x, p3.y) + vec2(p3.z, p3.x)));
+}
+
+vec4 hash42(vec2 p) {
+  vec4 p4 = fract(vec4(p.xyx, p.x + p.y) * vec4(0.1031, 0.11369, 0.13787, 0.09999));
+  p4 += dot(p4, p4.wzxy + 33.33);
+  return fract((p4.xxyz + p4.yzzw));
+}
+
+float noise12(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  vec2 u = f * f * (3.0 - 2.0 * f);
+  float a = hash12(i);
+  float b = hash12(i + vec2(1.0, 0.0));
+  float c = hash12(i + vec2(0.0, 1.0));
+  float d = hash12(i + vec2(1.0, 1.0));
+  float res = mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+  return res * 2.0 - 1.0;
+}
+
+void main() {
+  #include <uv_vertex>
+  #include <color_vertex>
+  #include <morphcolor_vertex>
+  #include <beginnormal_vertex>
+  #include <begin_vertex>
+
+  vec3 grassOffset = vec3(position.x, 0.0, position.y);
+
+  vec3 grassBladeWorldPos = (modelMatrix * vec4(grassOffset, 1.0)).xyz;
+  vec2 heightmapUV = vec2(
+    remap(grassBladeWorldPos.x, -heightParams.x * 0.5, heightParams.x * 0.5, 0.0, 1.0),
+    remap(grassBladeWorldPos.z, -heightParams.x * 0.5, heightParams.x * 0.5, 1.0, 0.0)
+  );
+  vec4 heightmapSample = texture2D(heightmap, heightmapUV);
+  grassBladeWorldPos.y += heightmapSample.x * grassParams.z - grassParams.w;
+
+  float heightmapSampleHeight = 1.0;
+  vec4 hashVal1 = hash42(vec2(grassBladeWorldPos.x, grassBladeWorldPos.z));
+
+  float distToCamera = distance(cameraPosition, grassBladeWorldPos);
+  float highLODOut = smoothstep(grassDraw.x * 0.5, grassDraw.x, distToCamera);
+  float lodFadeIn = smoothstep(grassDraw.x, grassDraw.y, distToCamera);
+
+  float isSandy = linearstep(-11.0, -14.0, grassBladeWorldPos.y);
+  float grassAllowedHash = hashVal1.w - isSandy;
+  float isGrassAllowed = step(0.0, grassAllowedHash);
+
+  float randomAngle = hashVal1.x * 2.0 * PI;
+  float randomShade = remap(hashVal1.y, -1.0, 1.0, 0.5, 1.0);
+  float randomHeight = remap(hashVal1.z, 0.0, 1.0, 0.75, 1.5) * mix(1.0, 0.0, lodFadeIn) * isGrassAllowed * heightmapSampleHeight;
+  float randomWidth = (1.0 - isSandy) * heightmapSampleHeight;
+  float randomLean = remap(hashVal1.w, 0.0, 1.0, 0.1, 0.4);
+
+  vec2 hashGrassColour = hash22(vec2(grassBladeWorldPos.x, grassBladeWorldPos.z));
+  float leanAnimation = noise12(vec2(time * 0.35) + grassBladeWorldPos.xz * 137.423) * 0.1;
+
+  float GRASS_SEGMENTS = grassParams.x;
+  float GRASS_VERTICES = grassParams.y;
+
+  float vertID = mod(float(vertIndex), GRASS_VERTICES);
+  float zSide = -(floor(vertIndex / GRASS_VERTICES) * 2.0 - 1.0);
+  float xSide = mod(vertID, 2.0);
+  float heightPercent = (vertID - xSide) / (GRASS_SEGMENTS * 2.0);
+
+  float grassTotalHeight = grassSize.y * randomHeight;
+  float grassTotalWidthHigh = easeOut(1.0 - heightPercent, 2.0);
+  float grassTotalWidthLow = 1.0 - heightPercent;
+  float grassTotalWidth = grassSize.x * mix(grassTotalWidthHigh, grassTotalWidthLow, highLODOut) * randomWidth;
+
+  float x = (xSide - 0.5) * grassTotalWidth;
+  float y = heightPercent * grassTotalHeight;
+
+  float windDir = noise12(grassBladeWorldPos.xz * 0.05 + 0.05 * time);
+  float windNoiseSample = noise12(grassBladeWorldPos.xz * 0.25 + time * 1.0);
+  float windLeanAngle = remap(windNoiseSample, -1.0, 1.0, 0.25, 1.0);
+  windLeanAngle = easeIn(windLeanAngle, 2.0) * 1.25;
+  vec3 windAxis = vec3(cos(windDir), 0.0, sin(windDir));
+  windLeanAngle *= heightPercent;
+
+  float distToPlayer = distance(grassBladeWorldPos.xz, playerPos.xz);
+  float playerFalloff = smoothstep(2.5, 1.0, distToPlayer);
+  float playerLeanAngle = mix(0.0, 0.2, playerFalloff * linearstep(0.5, 0.0, windLeanAngle));
+  vec3 grassToPlayer = normalize(vec3(playerPos.x, 0.0, playerPos.z) - vec3(grassBladeWorldPos.x, 0.0, grassBladeWorldPos.z));
+  vec3 playerLeanAxis = vec3(grassToPlayer.z, 0.0, -grassToPlayer.x);
+
+  randomLean += leanAnimation;
+
+  float easedHeight = mix(easeIn(heightPercent, 2.0), 1.0, highLODOut);
+  float curveAmount = -randomLean * easedHeight;
+
+  float ncurve1 = -randomLean * easedHeight;
+  vec3 n1 = vec3(0.0, (heightPercent + 0.01), 0.0);
+  n1 = rotateX(ncurve1) * n1;
+
+  float ncurve2 = -randomLean * easedHeight * 0.9;
+  vec3 n2 = vec3(0.0, (heightPercent + 0.01) * 0.9, 0.0);
+  n2 = rotateX(ncurve2) * n2;
+
+  vec3 ncurve = normalize(n1 - n2);
+
+  mat3 grassMat = rotateAxis(playerLeanAxis, playerLeanAngle) * rotateAxis(windAxis, windLeanAngle) * rotateY(randomAngle);
+
+  vec3 grassFaceNormal = vec3(0.0, 0.0, 1.0);
+  grassFaceNormal = grassMat * grassFaceNormal;
+  grassFaceNormal *= zSide;
+
+  vec3 grassVertexNormal = vec3(0.0, -ncurve.z, ncurve.y);
+  vec3 grassVertexNormal1 = rotateY(PI * 0.3 * zSide) * grassVertexNormal;
+  vec3 grassVertexNormal2 = rotateY(PI * -0.3 * zSide) * grassVertexNormal;
+
+  grassVertexNormal1 = grassMat * grassVertexNormal1;
+  grassVertexNormal1 *= zSide;
+
+  grassVertexNormal2 = grassMat * grassVertexNormal2;
+  grassVertexNormal2 *= zSide;
+
+  vec3 grassVertexPosition = vec3(x, y, 0.0);
+  grassVertexPosition = rotateX(curveAmount) * grassVertexPosition;
+  grassVertexPosition = grassMat * grassVertexPosition;
+
+  grassVertexPosition += grassOffset;
+
+  vec3 b1 = vec3(0.02, 0.075, 0.01);
+  vec3 b2 = vec3(0.025, 0.1, 0.01);
+  vec3 t1 = vec3(0.65, 0.8, 0.25);
+  vec3 t2 = vec3(0.8, 0.9, 0.4);
+
+  vec3 baseColour = mix(b1, b2, hashGrassColour.x);
+  vec3 tipColour = mix(t1, t2, hashGrassColour.y);
+  vec3 highLODColour = mix(baseColour, tipColour, easeIn(heightPercent, 4.0)) * randomShade;
+  vec3 lowLODColour = mix(b1, t1, heightPercent);
+  vGrassColour = mix(highLODColour, lowLODColour, highLODOut);
+  vGrassParams = vec4(heightPercent, grassBladeWorldPos.y, highLODOut, xSide);
+
+  const float SKY_RATIO = 0.25;
+  vec3 UP = vec3(0.0, 1.0, 0.0);
+  float skyFadeIn = (1.0 - highLODOut) * SKY_RATIO;
+  vec3 normal1 = normalize(mix(UP, grassVertexNormal1, skyFadeIn));
+  vec3 normal2 = normalize(mix(UP, grassVertexNormal2, skyFadeIn));
+
+  transformed = grassVertexPosition;
+  transformed.y += grassBladeWorldPos.y;
+
+  vec3 viewDir = normalize(cameraPosition - grassBladeWorldPos);
+  vec3 viewDirXZ = normalize(vec3(viewDir.x, 0.0, viewDir.z));
+  vec3 grassFaceNormalXZ = normalize(vec3(grassFaceNormal.x, 0.0, grassFaceNormal.z));
+  float viewDotNormal = saturate(dot(grassFaceNormal, viewDirXZ));
+  float viewSpaceThickenFactor = easeOut(1.0 - viewDotNormal, 4.0) * smoothstep(0.0, 0.2, viewDotNormal);
+
+  objectNormal = grassVertexNormal1;
+
+  #include <morphnormal_vertex>
+  #include <skinbase_vertex>
+  #include <skinnormal_vertex>
+  #include <defaultnormal_vertex>
+  #include <normal_vertex>
+
+  vNormal = normalize(normalMatrix * normal1);
+  vNormal2 = normalize(normalMatrix * normal2);
+
+  #include <morphtarget_vertex>
+  #include <skinning_vertex>
+  #include <displacementmap_vertex>
+
+  vec4 mvPosition = vec4(transformed, 1.0);
+#ifdef USE_INSTANCING
+  mvPosition = instanceMatrix * mvPosition;
+#endif
+  mvPosition = modelViewMatrix * mvPosition;
+  mvPosition.x += viewSpaceThickenFactor * (xSide - 0.5) * grassTotalWidth * 0.5 * zSide;
+
+  gl_Position = projectionMatrix * mvPosition;
+
+  #include <logdepthbuf_vertex>
+  #include <clipping_planes_vertex>
+  vViewPosition = -mvPosition.xyz;
+  #include <worldpos_vertex>
+  #include <envmap_vertex>
+  #include <shadowmap_vertex>
+  #include <fog_vertex>
+
+  vWorldPosition = worldPosition.xyz;
+}
+`;
+
+export const GRASS_FRAGMENT_SHADER = /* glsl */ `
+uniform vec3 emissive;
+uniform vec3 specular;
+uniform float shininess;
+uniform float opacity;
+#include <common>
+#include <packing>
+#include <dithering_pars_fragment>
+#include <color_pars_fragment>
+#include <uv_pars_fragment>
+#include <map_pars_fragment>
+#include <alphamap_pars_fragment>
+#include <alphatest_pars_fragment>
+#include <alphahash_pars_fragment>
+#include <aomap_pars_fragment>
+#include <lightmap_pars_fragment>
+#include <emissivemap_pars_fragment>
+#include <envmap_common_pars_fragment>
+#include <envmap_pars_fragment>
+#include <fog_pars_fragment>
+#include <bsdfs>
+#include <lights_pars_begin>
+#include <normal_pars_fragment>
+
+uniform vec3 grassLODColour;
+uniform float time;
+uniform mat3 normalMatrix;
+
+varying vec3 vGrassColour;
+varying vec4 vGrassParams;
+varying vec3 vNormal2;
+varying vec3 vWorldPosition;
+
+varying vec3 vViewPosition;
+
+struct BlinnPhongMaterial {
+  vec3 diffuseColor;
+  vec3 specularColor;
+  float specularShininess;
+  float specularStrength;
+};
+
+float easeIn(float x, float t) {
+  return pow(x, t);
+}
+
+vec3 applyFog(vec3 baseColour, float depth) {
+  float fogDensity = 0.015;
+  float fogFactor = exp(-fogDensity * fogDensity * depth * depth);
+  vec3 fogColour = vec3(0.65, 0.78, 0.92);
+  return mix(fogColour, baseColour, fogFactor);
+}
+
+void RE_Direct_BlinnPhong(const in IncidentLight directLight, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight) {
+  float wrap = 0.5;
+  float dotNL = saturate((dot(geometry.normal, directLight.direction) + wrap) / (1.0 + wrap));
+  vec3 irradiance = dotNL * directLight.color;
+  reflectedLight.directDiffuse += irradiance * BRDF_Lambert(material.diffuseColor);
+  reflectedLight.directSpecular += irradiance * BRDF_BlinnPhong(directLight.direction, geometry.viewDir, geometry.normal, material.specularColor, material.specularShininess) * material.specularStrength;
+
+  wrap = 0.5;
+  float backLight = saturate((dot(geometry.viewDir, -directLight.direction) + wrap) / (1.0 + wrap));
+  float falloff = 0.5;
+  vec3 scatter = directLight.color * pow(backLight, 1.0) * falloff * BRDF_Lambert(material.diffuseColor);
+  reflectedLight.indirectDiffuse += scatter * (1.0 - vGrassParams.z);
+}
+
+void RE_IndirectDiffuse_BlinnPhong(const in vec3 irradiance, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight) {
+  reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert(material.diffuseColor);
+}
+
+#define RE_Direct RE_Direct_BlinnPhong
+#define RE_IndirectDiffuse RE_IndirectDiffuse_BlinnPhong
+
+#include <shadowmap_pars_fragment>
+#include <bumpmap_pars_fragment>
+#include <normalmap_pars_fragment>
+#include <specularmap_pars_fragment>
+#include <logdepthbuf_pars_fragment>
+#include <clipping_planes_pars_fragment>
+
+void main() {
+  vec3 viewDir = normalize(cameraPosition - vWorldPosition);
+  #include <clipping_planes_fragment>
+  vec4 diffuseColor = vec4(diffuse, opacity);
+
+  float heightPercent = vGrassParams.x;
+  float height = vGrassParams.y;
+  float lodFadeIn = vGrassParams.z;
+  float lodFadeOut = 1.0 - lodFadeIn;
+
+  float grassMiddle = mix(smoothstep(abs(vGrassParams.w - 0.5), 0.0, 0.1), 1.0, lodFadeIn);
+  float isSandy = saturate(linearstep(-11.0, -14.0, height));
+  float density = 1.0 - isSandy;
+  float aoForDensity = mix(1.0, 0.25, density);
+  float ao = mix(aoForDensity, 1.0, easeIn(heightPercent, 2.0));
+
+  diffuseColor.rgb *= vGrassColour;
+  diffuseColor.rgb *= mix(0.85, 1.0, grassMiddle);
+  diffuseColor.rgb *= ao;
+
+  ReflectedLight reflectedLight = ReflectedLight(vec3(0.0), vec3(0.0), vec3(0.0), vec3(0.0));
+  vec3 totalEmissiveRadiance = emissive;
+  #include <logdepthbuf_fragment>
+  #include <map_fragment>
+  #include <color_fragment>
+  #include <alphamap_fragment>
+  #include <alphatest_fragment>
+  #include <alphahash_fragment>
+  #include <specularmap_fragment>
+  #include <normal_fragment_begin>
+  #include <normal_fragment_maps>
+
+  vec3 normal2 = normalize(vNormal2);
+  normal = normalize(mix(vNormal, normal2, vGrassParams.w));
+
+  #include <emissivemap_fragment>
+
+  BlinnPhongMaterial material;
+  material.diffuseColor = diffuseColor.rgb;
+  material.specularColor = specular;
+  material.specularShininess = shininess;
+  material.specularStrength = specularStrength;
+
+  #include <lights_fragment_begin>
+  #include <lights_fragment_maps>
+  #include <lights_fragment_end>
+  #include <aomap_fragment>
+  vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;
+
+  #include <envmap_fragment>
+  #include <opaque_fragment>
+  #include <tonemapping_fragment>
+  #include <colorspace_fragment>
+
+  float fogDepth = length(vViewPosition);
+  gl_FragColor.rgb = applyFog(gl_FragColor.rgb, fogDepth);
+
+  #include <premultiplied_alpha_fragment>
+  #include <dithering_fragment>
+}
+`;
+
+export type GrassShader = Shader;


### PR DESCRIPTION
## Summary
- add a `/grass-v3` demo route that mounts a dynamic GrassV3 React Three Fiber scene
- implement the GrassV3 scene with a procedural heightmap terrain, animated player marker, and environment lighting
- port the Quick_Grass instanced grass pipeline with custom shaders, reusable geometry, and runtime LOD management

## Testing
- npm run lint *(fails: existing repository lint issues unrelated to the new demo)*

------
https://chatgpt.com/codex/tasks/task_e_68cd317af894832fbb71656a11641141