### PR TITLE
Add machine unit tests and wire into CI

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run unit tests
+        run: npm run test:machines
+
       - name: Build planner WASM (Docker)
         run: npm run build:planner
 

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run unit tests
+        run: npm run test:machines
+
       - name: Build planner WASM (Docker)
         run: npm run build:planner
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "biome format --write",
     "//pretest": "npm run build:planner",
     "test": "vitest run",
+    "test:machines": "node scripts/run-machine-tests.mjs",
     "test:debug": "FLUIDHTN_DEBUG=1 npm run test",
     "build:planner": "bash ./scripts/build_fluidhtn_docker.sh",
     "build:planner:watch": "npm --prefix ../.. run fluidhtn:watch",

--- a/scripts/run-machine-tests.mjs
+++ b/scripts/run-machine-tests.mjs
@@ -1,0 +1,19 @@
+import { readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startVitest } from 'vitest/node';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const testsDir = join(__dirname, '..', 'src', 'tests');
+const files = readdirSync(testsDir)
+  .filter((file) => file.endsWith('.machine.test.ts'))
+  .map((file) => join('src', 'tests', file));
+
+if (files.length === 0) {
+  console.error('No machine test files found.');
+  process.exit(1);
+}
+
+const ctx = await startVitest('run', files);
+const exitCode = await ctx?.close();
+process.exit(exitCode ?? 0);

--- a/src/tests/audioRecorder.machine.test.ts
+++ b/src/tests/audioRecorder.machine.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { assign, createActor } from 'xstate';
+import { audioRecorderMachine } from '../machines/audioRecorder.machine';
+
+describe('audioRecorderMachine', () => {
+  const testMachine = audioRecorderMachine.provide({
+    actions: {
+      requestStream: () => {},
+      prepareRecorder: () => {},
+      startRecorder: () => {},
+      stopRecorder: () => {},
+      startDataInterval: assign(() => ({ dataIntervalId: 1 })),
+      clearDataInterval: assign(() => ({ dataIntervalId: null })),
+      requestDataNow: () => {},
+      emitParentData: () => {},
+      emitParentAcquired: () => {},
+    },
+  });
+
+  it('transitions through acquisition and records chunks', () => {
+    const actor = createActor(testMachine, {
+      input: { sampleRate: 16000, mimeType: 'audio/webm', dataRequestInterval: 100 },
+    });
+    actor.start();
+
+    expect(actor.getSnapshot().value).toBe('acquiring');
+
+    const stream = {} as MediaStream;
+    actor.send({ type: 'ACQUIRED', stream });
+    expect(actor.getSnapshot().value).toBe('preparing');
+    expect(actor.getSnapshot().context.stream).toBe(stream);
+
+    const recorder = { state: 'inactive' } as unknown as MediaRecorder;
+    actor.send({ type: 'PREPARED', recorder });
+    expect(actor.getSnapshot().value).toBe('ready');
+    expect(actor.getSnapshot().context.recorder).toBe(recorder);
+
+    actor.send({ type: 'START' });
+    expect(actor.getSnapshot().value).toBe('recording');
+
+    const blob = new Blob(['hello'], { type: 'text/plain' });
+    actor.send({ type: 'DATA_AVAILABLE', blob });
+    expect(actor.getSnapshot().context.chunks).toHaveLength(1);
+
+    actor.send({ type: 'STOP' });
+    expect(actor.getSnapshot().value).toBe('ready');
+
+    actor.send({ type: 'RESET' });
+    expect(actor.getSnapshot().context.chunks).toHaveLength(0);
+  });
+
+  it('captures errors during acquisition', () => {
+    const actor = createActor(testMachine, {
+      input: { sampleRate: 16000, mimeType: 'audio/webm', dataRequestInterval: 100 },
+    });
+    actor.start();
+
+    actor.send({ type: 'ACQUIRE_FAILED', error: 'no mic' });
+    expect(actor.getSnapshot().value).toBe('error');
+    expect(actor.getSnapshot().context.error).toBe('no mic');
+  });
+});

--- a/src/tests/kokoroChunker.machine.test.ts
+++ b/src/tests/kokoroChunker.machine.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { assign, createActor } from 'xstate';
+import { kokoroChunkerMachine } from '../machines/kokoroChunker.machine';
+
+describe('kokoroChunkerMachine', () => {
+  it('pushes chunks and marks them ready after TTS completes', async () => {
+    const generateMock = vi.fn().mockResolvedValue({ url: 'mock-audio' });
+    const clientStub = {
+      isReady: true,
+      generate: generateMock,
+    } as unknown as import('../lib/tts/kokoro-worker-client').KokoroWorkerClient;
+
+    const machine = kokoroChunkerMachine.provide({
+      actions: {
+        createClient: assign(() => ({ client: clientStub })),
+      },
+    });
+
+    const utteranceSpy = vi.fn();
+    const actor = createActor(machine, { input: { onUtteranceGenerated: utteranceSpy } });
+    actor.start();
+
+    actor.send({ type: 'WORKER.READY', voices: { voice1: {} }, device: 'cpu' });
+
+    actor.send({ type: 'UI.SET_TEXT', text: 'Hello world.' });
+    actor.send({ type: 'UI.PUSH_CHUNK' });
+
+    const afterPush = actor.getSnapshot().context.uiChunks;
+    expect(afterPush).toHaveLength(1);
+    expect(afterPush[0].status).toBe('generating');
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const chunk = actor.getSnapshot().context.uiChunks[0];
+    expect(['ready', 'playing']).toContain(chunk.status);
+    expect(chunk.audioUrl).toBe('mock-audio');
+    expect(generateMock).toHaveBeenCalledWith({ text: chunk.text, voice: 'voice1', speed: actor.getSnapshot().context.speed });
+    expect(utteranceSpy).toHaveBeenCalledWith(expect.objectContaining({ id: chunk.id, audioUrl: 'mock-audio' }));
+  });
+});

--- a/src/tests/kokoroTts.machine.test.ts
+++ b/src/tests/kokoroTts.machine.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { assign, createActor } from 'xstate';
+import { kokoroTtsMachine } from '../machines/kokoroTts.machine';
+
+describe('kokoroTtsMachine', () => {
+  it('boots, becomes ready, and generates audio', async () => {
+    const generateMock = vi.fn().mockResolvedValue({ url: 'mock-url' });
+    const clientStub = {
+      isReady: true,
+      generate: generateMock,
+      dispose: vi.fn(),
+      init: vi.fn(),
+    } as unknown as import('../lib/tts/kokoro-worker-client').KokoroWorkerClient;
+
+    const machine = kokoroTtsMachine.provide({
+      actions: {
+        createClient: assign(() => ({ client: clientStub })),
+        disposeClient: () => {},
+      },
+    });
+
+    const utteranceSpy = vi.fn();
+    const actor = createActor(machine, { input: { onUtteranceGenerated: utteranceSpy } });
+
+    actor.start();
+    expect(actor.getSnapshot().value).toBe('boot');
+
+    actor.send({ type: 'WORKER.READY', voices: { voiceA: {} }, device: 'cpu' });
+    const snapshotAfterReady = actor.getSnapshot();
+    expect(snapshotAfterReady.value).toBe('ready');
+    expect(snapshotAfterReady.context.selectedSpeaker).toBe('voiceA');
+
+    actor.send({ type: 'USER.SET_TEXT', text: 'Hello there' });
+    actor.send({ type: 'USER.GENERATE' });
+    expect(actor.getSnapshot().value).toBe('generating');
+
+    await new Promise<void>((resolve, reject) => {
+      const subscription = actor.subscribe((state) => {
+        if (state.value === 'ready' && state.context.synthesizedUtterances.length > 0) {
+          subscription.unsubscribe();
+          resolve();
+        }
+      });
+      setTimeout(() => {
+        subscription.unsubscribe();
+        reject(new Error('generation timeout'));
+      }, 2000);
+    });
+
+    expect(generateMock).toHaveBeenCalledWith(expect.objectContaining({ text: 'Hello there', voice: 'voiceA' }));
+
+    const { synthesizedUtterances } = actor.getSnapshot().context;
+    expect(synthesizedUtterances[0]).toMatchObject({ text: 'Hello there', src: 'mock-url' });
+    expect(utteranceSpy).toHaveBeenCalledWith(expect.objectContaining({ src: 'mock-url' }));
+  });
+});

--- a/src/tests/sentenceChunker.machine.test.ts
+++ b/src/tests/sentenceChunker.machine.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { createActor } from 'xstate';
+import { sentenceChunkerMachine } from '../machines/sentenceChunker.machine';
+
+describe('sentenceChunkerMachine', () => {
+  it('initializes chunker and accumulates pushed text', () => {
+    const actor = createActor(sentenceChunkerMachine);
+    actor.start();
+
+    expect(actor.getSnapshot().value).toBe('idle');
+
+    actor.send({ type: 'INIT' });
+    expect(actor.getSnapshot().value).toBe('ready');
+
+    actor.send({ type: 'PUSH', text: 'Hello world. This is a test.' });
+    expect(actor.getSnapshot().context.chunks.length).toBeGreaterThan(0);
+
+    const preFlushLength = actor.getSnapshot().context.chunks.length;
+    actor.send({ type: 'FLUSH' });
+    expect(actor.getSnapshot().context.chunks.length).toBeGreaterThanOrEqual(preFlushLength);
+
+    actor.send({ type: 'RESET', options: { locale: 'en', charLimit: 42 } });
+    const ctx = actor.getSnapshot().context;
+    expect(ctx.options.charLimit).toBe(42);
+    expect(ctx.chunks).toHaveLength(0);
+    expect(ctx.chunker).not.toBeNull();
+  });
+});

--- a/src/tests/speechRecognition.machine.test.ts
+++ b/src/tests/speechRecognition.machine.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createActor } from 'xstate';
+import { speechRecognitionMachine } from '../machines/speechRecognition.machine';
+
+describe('speechRecognitionMachine', () => {
+  it('loads, generates, and completes recognition', () => {
+    const postGenerate = vi.fn();
+    const machine = speechRecognitionMachine.provide({
+      actions: {
+        ensureWorker: () => {},
+        postLoad: () => {},
+        postLoadIfReady: () => {},
+        postLoadIfRequested: () => {},
+        emitParentLoading: () => {},
+        emitParentReady: () => {},
+        emitParentUpdate: () => {},
+        emitParentComplete: () => {},
+        emitParentError: () => {},
+        notifyLoading: () => {},
+        notifyReady: () => {},
+        notifyStart: () => {},
+        notifyUpdate: () => {},
+        notifyComplete: () => {},
+        notifyError: () => {},
+        postGenerate,
+      },
+    });
+
+    const actor = createActor(machine, { input: { language: 'en' } });
+    actor.start();
+
+    expect(actor.getSnapshot().value).toBe('boot');
+
+    const workerStub = { postMessage: vi.fn(), terminate: vi.fn() } as unknown as Worker;
+    actor.send({ type: 'WORKER_ATTACHED', worker: workerStub });
+    expect(actor.getSnapshot().context.worker).toBe(workerStub);
+
+    actor.send({ type: 'LOAD' });
+    expect(actor.getSnapshot().value).toBe('loading');
+    expect(actor.getSnapshot().context.loadRequested).toBe(true);
+
+    actor.send({ type: 'WORKER_LOADING' });
+    expect(actor.getSnapshot().context.status).toBe('loading');
+
+    actor.send({ type: 'WORKER_READY' });
+    expect(actor.getSnapshot().value).toBe('ready');
+    expect(actor.getSnapshot().context.status).toBe('ready');
+
+    const audio = new Float32Array([0.1, 0.2, 0.3]);
+    actor.send({ type: 'GENERATE', audio, language: 'en' });
+    expect(actor.getSnapshot().value).toBe('generating');
+    expect(postGenerate).toHaveBeenCalled();
+
+    actor.send({ type: 'WORKER_START' });
+    expect(actor.getSnapshot().context.status).toBe('start');
+
+    actor.send({ type: 'WORKER_UPDATE', output: 'partial', tps: 5 });
+    expect(actor.getSnapshot().context.status).toBe('update');
+    expect(actor.getSnapshot().context.text).toBe('partial');
+    expect(actor.getSnapshot().context.tps).toBe(5);
+
+    actor.send({ type: 'WORKER_COMPLETE', output: 'final transcript' });
+    expect(actor.getSnapshot().value).toBe('ready');
+    expect(actor.getSnapshot().context.status).toBe('complete');
+    expect(actor.getSnapshot().context.text).toBe('final transcript');
+  });
+});

--- a/src/tests/ttsQueue.machine.test.ts
+++ b/src/tests/ttsQueue.machine.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { assign, createActor } from 'xstate';
+import { ttsQueueMachine } from '../machines/ttsQueue.machine';
+
+describe('ttsQueueMachine', () => {
+  it('manages playback state and progress', () => {
+    const items = [
+      { audioUrl: 'a.mp3', status: 'ready' as const },
+      { audioUrl: 'b.mp3', status: 'ready' as const },
+    ];
+
+    const statusSpy = vi.fn();
+
+    const machine = ttsQueueMachine.provide({
+      actions: {
+        startPlayback: () => {},
+        pausePlayback: () => {},
+        resumePlayback: () => {},
+        stopPlayback: assign(() => ({ autoplay: false, isUserPaused: false, progressRatio: 0, activeAudioIndex: 0 })),
+      },
+    });
+
+    const actor = createActor(machine, { input: { items, onStatusChange: statusSpy } });
+    actor.start();
+
+    expect(actor.getSnapshot().value).toBe('idle');
+
+    actor.send({ type: 'PLAY' });
+    expect(actor.getSnapshot().value).toBe('playing');
+    expect(statusSpy).toHaveBeenCalledWith(0, 'playing');
+
+    actor.send({ type: 'AUDIO_TIMEUPDATE', progress: 0.5 });
+    expect(actor.getSnapshot().context.progressRatio).toBeCloseTo(0.5);
+
+    actor.send({ type: 'PAUSE' });
+    expect(actor.getSnapshot().value).toBe('paused');
+    expect(statusSpy).toHaveBeenCalledWith(0, 'paused');
+
+    actor.send({ type: 'STOP' });
+    expect(actor.getSnapshot().value).toBe('idle');
+    expect(actor.getSnapshot().context.autoplay).toBe(false);
+  });
+});

--- a/src/tests/voiceSegments.machine.test.ts
+++ b/src/tests/voiceSegments.machine.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createActor } from 'xstate';
+import { voiceSegmentsMachine } from '../machines/voiceSegments.machine';
+
+describe('voiceSegmentsMachine', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('flushes immediately when whisper completes during settling', async () => {
+    const actor = createActor(voiceSegmentsMachine, { input: { settleMs: 100, whisperWaitMs: 300 } });
+    actor.start();
+
+    actor.send({ type: 'VAD.START' });
+    actor.send({ type: 'LIVE_UPDATE', text: 'hello world' });
+    actor.send({ type: 'VAD.END' });
+    expect(actor.getSnapshot().value).toBe('settling');
+
+    actor.send({ type: 'WHISPER.STATUS', status: 'complete' });
+    vi.advanceTimersByTime(100);
+    await Promise.resolve();
+
+    expect(actor.getSnapshot().value).toBe('idle');
+    expect(actor.getSnapshot().context.lastFinalText).toBe('hello world');
+    expect(actor.getSnapshot().context.liveText).toBe('');
+  });
+
+  it('waits for whisper completion before flushing', async () => {
+    const actor = createActor(voiceSegmentsMachine, { input: { settleMs: 50, whisperWaitMs: 150 } });
+    actor.start();
+
+    actor.send({ type: 'VAD.START' });
+    actor.send({ type: 'LIVE_UPDATE', text: 'partial result' });
+    actor.send({ type: 'VAD.END' });
+
+    vi.advanceTimersByTime(50);
+    await Promise.resolve();
+
+    expect(actor.getSnapshot().value).toBe('waitingWhisper');
+    expect(actor.getSnapshot().context.waitingForWhisper).toBe(true);
+
+    vi.advanceTimersByTime(150);
+    await Promise.resolve();
+
+    expect(actor.getSnapshot().value).toBe('idle');
+    expect(actor.getSnapshot().context.lastFinalText).toBe('partial result');
+  });
+});

--- a/src/tests/whisper.machine.test.ts
+++ b/src/tests/whisper.machine.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { createActor } from 'xstate';
+import { whisperLocalMachine } from '../machines/whisper.machine';
+
+describe('whisperLocalMachine', () => {
+  it('updates and resets segment metadata', () => {
+    const actor = createActor(whisperLocalMachine);
+    actor.start();
+
+    actor.send({ type: 'SET_PROCESSING', value: true });
+    actor.send({ type: 'SET_FINALIZING', value: true });
+    actor.send({ type: 'SET_SEGMENT_START', index: 3 });
+    actor.send({ type: 'SET_LAST_DECODED_COUNT', count: 4 });
+    const blob = new Blob(['header']);
+    actor.send({ type: 'SET_HEADER_CHUNK', blob });
+
+    expect(actor.getSnapshot().context).toMatchObject({
+      isProcessing: true,
+      finalizing: true,
+      segmentStartIndex: 3,
+      lastDecodedChunkCount: 4,
+      headerChunk: blob,
+    });
+
+    actor.send({ type: 'RESET_SEGMENT' });
+    expect(actor.getSnapshot().context.segmentStartIndex).toBe(0);
+    expect(actor.getSnapshot().context.lastDecodedChunkCount).toBe(0);
+    expect(actor.getSnapshot().context.headerChunk).toBeNull();
+  });
+});

--- a/src/tests/whisperOrchestrator.machine.test.ts
+++ b/src/tests/whisperOrchestrator.machine.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { createWhisperOrchestratorMachine } from '../machines/whisperOrchestrator.machine';
+
+describe('whisperOrchestratorMachine', () => {
+  it('exports a machine factory', () => {
+    expect(typeof createWhisperOrchestratorMachine).toBe('function');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,50 +3,56 @@ import { defineConfig } from 'vitest/config';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
-const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
-// More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
+const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+const includeStorybook = process.env.RUN_STORYBOOK_TESTS === '1';
+
+const nodeProject = {
+  test: {
+    environment: 'node' as const,
+    globals: true,
+    include: ['src/**/*.{test,spec}.{ts,js}'],
+    testTimeout: 30000,
+    hookTimeout: 60000,
+  },
+};
+
+const projects = [nodeProject];
+
+if (includeStorybook) {
+  projects.push({
+    extends: true,
+    plugins: [
+      // The plugin will run tests for the stories defined in your Storybook config
+      // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
+      storybookTest({
+        configDir: path.join(dirname, '.storybook'),
+      }),
+    ],
+    test: {
+      name: 'storybook',
+      browser: {
+        enabled: true,
+        headless: true,
+        provider: 'playwright',
+        instances: [
+          {
+            browser: 'chromium',
+          },
+        ],
+      },
+      setupFiles: ['.storybook/vitest.setup.ts'],
+    },
+  });
+}
+
 export default defineConfig({
   test: {
-    // This config is used for the default (node) test project
     environment: 'node',
     globals: true,
     include: ['src/**/*.{test,spec}.{ts,js}'],
     testTimeout: 30000,
     hookTimeout: 60000,
-    projects: [
-      // Node tests (default)
-      {
-        test: {
-          environment: 'node',
-          globals: true,
-          include: ['src/**/*.{test,spec}.{ts,js}'],
-          testTimeout: 30000,
-          hookTimeout: 60000,
-        }
-      },
-      // Storybook tests (browser)
-      {
-        extends: true,
-        plugins: [
-        // The plugin will run tests for the stories defined in your Storybook config
-        // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
-        storybookTest({
-          configDir: path.join(dirname, '.storybook')
-        })],
-        test: {
-          name: 'storybook',
-          browser: {
-            enabled: true,
-            headless: true,
-            provider: 'playwright',
-            instances: [{
-              browser: 'chromium'
-            }]
-          },
-          setupFiles: ['.storybook/vitest.setup.ts']
-        }
-      }
-    ]
-  }
+    projects,
+  },
 });


### PR DESCRIPTION
## Summary
- add Vitest suites that exercise each XState machine under src/machines
- gate Storybook Vitest project behind RUN_STORYBOOK_TESTS and add a script to launch only machine specs
- execute the machine-focused test run in both preview and production GitHub Actions workflows

## Testing
- npm run test:machines

------
https://chatgpt.com/codex/tasks/task_e_68d12d859d3c832faa367a945b3005c8