### PR TITLE
Add volumetric dust GPU demo page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,63 +18,80 @@ const demoCategories: DemoCategory[] = [
         href: "/three",
         icon: "🎲",
         title: "THREE.js Demo",
-        description: "Basic THREE.js setup with interactive 3D scene. A starting point for 3D web graphics."
+        description:
+          "Basic THREE.js setup with interactive 3D scene. A starting point for 3D web graphics.",
       },
       {
         href: "/humanoid-demo",
         icon: "🧍",
         title: "Universal Humanoid",
-        description: "Optimized 3D character model with 45 animations. Demonstrates instanced rendering and animation blending with gltfjsx."
+        description:
+          "Optimized 3D character model with 45 animations. Demonstrates instanced rendering and animation blending with gltfjsx.",
       },
       {
         href: "/animation-mixer-demo",
         icon: "🎭",
         title: "Animation State Machine",
-        description: "Advanced animation blending with 2D blend spaces, layered animations, and state machines. Features parameter damping, masked layers, and smooth transitions."
+        description:
+          "Advanced animation blending with 2D blend spaces, layered animations, and state machines. Features parameter damping, masked layers, and smooth transitions.",
       },
       {
         href: "/grass",
         icon: "🌿",
         title: "Grass Demo (V1)",
-        description: "First iteration of procedural grass rendering. Features basic wind simulation and LOD optimization."
+        description:
+          "First iteration of procedural grass rendering. Features basic wind simulation and LOD optimization.",
       },
       {
         href: "/grass-v2",
         icon: "🌱",
         title: "Grass Demo (V2)",
-        description: "Enhanced grass rendering with improved shaders. Better performance and more realistic movement."
+        description:
+          "Enhanced grass rendering with improved shaders. Better performance and more realistic movement.",
       },
       {
         href: "/instanced-mesh2",
         icon: "🔲",
         title: "Instanced Mesh2 Demo",
-        description: "Advanced instanced mesh rendering for thousands of objects. Demonstrates GPU optimization techniques."
+        description:
+          "Advanced instanced mesh rendering for thousands of objects. Demonstrates GPU optimization techniques.",
       },
       {
         href: "/materials",
         icon: "🎨",
         title: "Materials Gallery",
-        description: "Comprehensive WebGPU materials showcase featuring 10 procedural wood types (40 variations) and 8 industry-standard MaterialX materials. All displayed in a unified grid with interactive controls. Includes chrome, copper, gold, jade, marble, velvet, plastic, and brushed metal."
+        description:
+          "Comprehensive WebGPU materials showcase featuring 10 procedural wood types (40 variations) and 8 industry-standard MaterialX materials. All displayed in a unified grid with interactive controls. Includes chrome, copper, gold, jade, marble, velvet, plastic, and brushed metal.",
       },
       {
         href: "/decals-demo",
         icon: "🎯",
         title: "Instanced Decals Demo",
-        description: "Click-to-place decals on instanced meshes with BatchedMesh for efficient rendering. Demonstrates raycasting, DecalGeometry, and ring buffer optimization with up to 2000 decals in a single draw call."
+        description:
+          "Click-to-place decals on instanced meshes with BatchedMesh for efficient rendering. Demonstrates raycasting, DecalGeometry, and ring buffer optimization with up to 2000 decals in a single draw call.",
       },
       {
         href: "/decals-csg-demo",
         icon: "🕳️",
         title: "Decals + CSG Holes",
-        description: "Shoot decals and subtract cylindrical holes via CSG. Proof-of-concept that combines surface decals with boolean subtraction on instanced geometry."
+        description:
+          "Shoot decals and subtract cylindrical holes via CSG. Proof-of-concept that combines surface decals with boolean subtraction on instanced geometry.",
       },
       {
         href: "/gpu-rain",
         icon: "🌧️",
         title: "GPU Compute Particles Rain",
-        description: "WebGPU compute shader rain simulation with 50,000 particles. Features real-time collision detection via render-to-texture, GPU-driven particle physics, and dynamic ripple effects."
-      }
-    ]
+        description:
+          "WebGPU compute shader rain simulation with 50,000 particles. Features real-time collision detection via render-to-texture, GPU-driven particle physics, and dynamic ripple effects.",
+      },
+      {
+        href: "/volumetric-dust",
+        icon: "🌫️",
+        title: "Volumetric Dust (GPU)",
+        description:
+          "Three.js GPUComputationRenderer dust tile with ray-marched volumetric compositing and interactive emission trigger.",
+      },
+    ],
   },
   {
     name: "Physics & Terrain",
@@ -83,63 +100,73 @@ const demoCategories: DemoCategory[] = [
         href: "/three-pinata",
         icon: "🎪",
         title: "THREE.js + Pinata",
-        description: "Interactive 3D piñata with physics simulation. Break it open with realistic destruction effects!"
+        description:
+          "Interactive 3D piñata with physics simulation. Break it open with realistic destruction effects!",
       },
       {
         href: "/heightfield-demo",
         icon: "🏔️",
         title: "Heightfield Physics Demo",
-        description: "Interactive terrain with Rapier physics integration. Demonstrates collision detection on height maps."
+        description:
+          "Interactive terrain with Rapier physics integration. Demonstrates collision detection on height maps.",
       },
       {
         href: "/heightfield-dynamic",
         icon: "⛰️",
         title: "Heightfield (Dynamic)",
-        description: "Real-time deformable terrain system. Modify the landscape dynamically with physics interactions."
+        description:
+          "Real-time deformable terrain system. Modify the landscape dynamically with physics interactions.",
       },
       {
         href: "/heightfield-simple",
         icon: "🗻",
         title: "Heightfield (Simple)",
-        description: "Simplified heightfield implementation for learning. Clean code structure for understanding the basics."
+        description:
+          "Simplified heightfield implementation for learning. Clean code structure for understanding the basics.",
       },
       {
         href: "/heightfield-craters",
         icon: "💥",
         title: "Heightfield (Craters)",
-        description: "Dynamic crater creation on terrain surfaces. Creates realistic impact deformations with physics."
+        description:
+          "Dynamic crater creation on terrain surfaces. Creates realistic impact deformations with physics.",
       },
       {
         href: "/bunker-rapier",
         icon: "⚡",
         title: "Bunker (Rapier Physics)",
-        description: "Bunker demo powered by Rapier physics engine. Fast and accurate physics simulation in the browser."
+        description:
+          "Bunker demo powered by Rapier physics engine. Fast and accurate physics simulation in the browser.",
       },
       {
         href: "/destructible-wall",
         icon: "🧱",
         title: "Destructible Wall",
-        description: "Breakable wall system with realistic destruction. Uses physics constraints and fracture patterns."
-      }
-      ,{
+        description:
+          "Breakable wall system with realistic destruction. Uses physics constraints and fracture patterns.",
+      },
+      {
         href: "/destructible-stress",
         icon: "🧱",
         title: "Destructible (Stress Solver)",
-        description: "Single-body colliders + Blast Stress Solver with safe-frame splitting and debug lines."
-      }
-      ,{
+        description:
+          "Single-body colliders + Blast Stress Solver with safe-frame splitting and debug lines.",
+      },
+      {
         href: "/shockwave-demo",
         icon: "💣",
         title: "Shockwave Demo",
-        description: "Interactive explosive shockwave with presets (TNT/C4/etc.) and simple scenes."
-      }
-      ,{
+        description:
+          "Interactive explosive shockwave with presets (TNT/C4/etc.) and simple scenes.",
+      },
+      {
         href: "/ragdoll",
         icon: "🧍",
         title: "Ragdoll Physics",
-        description: "Spawn humanoid ragdolls with Rapier joints. Click to place them on varied terrain; toggle debug and gravity with Leva."
-      }
-    ]
+        description:
+          "Spawn humanoid ragdolls with Rapier joints. Click to place them on varied terrain; toggle debug and gravity with Leva.",
+      },
+    ],
   },
   {
     name: "AI & Game Logic",
@@ -148,27 +175,31 @@ const demoCategories: DemoCategory[] = [
         href: "/ai-world",
         icon: "🌐",
         title: "AI World (Advanced)",
-        description: "Advanced 3D interactive world with physics, multiple AI NPCs, action system, and Gemini chat integration. Complete ECS-style world with HTN planning."
+        description:
+          "Advanced 3D interactive world with physics, multiple AI NPCs, action system, and Gemini chat integration. Complete ECS-style world with HTN planning.",
       },
       {
         href: "/bunker",
         icon: "🏰",
         title: "Bunker Mission (HTN)",
-        description: "AI-driven NPCs using Hierarchical Task Networks. Watch soldiers plan and execute tactical missions."
+        description:
+          "AI-driven NPCs using Hierarchical Task Networks. Watch soldiers plan and execute tactical missions.",
       },
       {
         href: "/bunker-fluid",
         icon: "💧",
         title: "Bunker (Fluid HTN + WASM)",
-        description: "Advanced HTN planning with WASM performance. Fluid HTN allows dynamic replanning during execution."
+        description:
+          "Advanced HTN planning with WASM performance. Fluid HTN allows dynamic replanning during execution.",
       },
       {
         href: "/fluid-demo",
         icon: "🧩",
         title: "Fluid HTN Demo",
-        description: "Pure demonstration of Fluid HTN planning system. See how AI agents decompose complex tasks."
-      }
-    ]
+        description:
+          "Pure demonstration of Fluid HTN planning system. See how AI agents decompose complex tasks.",
+      },
+    ],
   },
   {
     name: "Chat & Conversation",
@@ -177,33 +208,38 @@ const demoCategories: DemoCategory[] = [
         href: "/ai-chat",
         icon: "🤖",
         title: "AI Chat",
-        description: "Basic AI chat interface with streaming responses. Connect to various LLM providers for conversation."
+        description:
+          "Basic AI chat interface with streaming responses. Connect to various LLM providers for conversation.",
       },
       {
         href: "/ai-chat-advanced",
         icon: "🧠",
         title: "AI Chat (Advanced)",
-        description: "Enhanced chat with advanced features and context. Includes memory and conversation management."
+        description:
+          "Enhanced chat with advanced features and context. Includes memory and conversation management.",
       },
       {
         href: "/npc-chat",
         icon: "🧑‍🚀",
         title: "NPC Chat",
-        description: "Interactive NPC conversations with personality. Game-ready dialogue system with character traits."
+        description:
+          "Interactive NPC conversations with personality. Game-ready dialogue system with character traits.",
       },
       {
         href: "/npc-chat-physics",
         icon: "🎮",
         title: "NPC Chat (Physics)",
-        description: "NPC chat with Rapier physics. Both player and NPCs use character controllers that collide with walls!"
+        description:
+          "NPC chat with Rapier physics. Both player and NPCs use character controllers that collide with walls!",
       },
       {
         href: "/ai-text-world",
         icon: "🌍",
         title: "AI Text World",
-        description: "Text-based virtual world with AI tool calling. Chat with an AI agent that can move, perform actions, and interact with the environment using real-time tool execution."
-      }
-    ]
+        description:
+          "Text-based virtual world with AI tool calling. Chat with an AI agent that can move, perform actions, and interact with the environment using real-time tool execution.",
+      },
+    ],
   },
   {
     name: "Audio & Speech",
@@ -212,33 +248,38 @@ const demoCategories: DemoCategory[] = [
         href: "/whisper",
         icon: "🔊",
         title: "Whisper STT",
-        description: "OpenAI Whisper speech-to-text in the browser. High-quality transcription running locally."
+        description:
+          "OpenAI Whisper speech-to-text in the browser. High-quality transcription running locally.",
       },
       {
         href: "/kokoro-tts",
         icon: "🗣️",
         title: "Kokoro TTS",
-        description: "Text-to-speech synthesis using Kokoro model. Natural-sounding voice generation in real-time."
+        description:
+          "Text-to-speech synthesis using Kokoro model. Natural-sounding voice generation in real-time.",
       },
       {
         href: "/vad",
         icon: "🎙️",
         title: "VAD Demo",
-        description: "Voice Activity Detection using Silero VAD. Detect when someone is speaking with low latency."
+        description:
+          "Voice Activity Detection using Silero VAD. Detect when someone is speaking with low latency.",
       },
       {
         href: "/voice-to-voice",
         icon: "🎤",
         title: "Voice to Voice",
-        description: "Real-time voice conversation system. Combines STT, AI, and TTS for natural dialogue."
+        description:
+          "Real-time voice conversation system. Combines STT, AI, and TTS for natural dialogue.",
       },
       {
         href: "/kokoro-chunker",
         icon: "✂️",
         title: "Kokoro Chunker",
-        description: "Smart text chunking for TTS processing. Splits text at natural boundaries for smoother speech."
-      }
-    ]
+        description:
+          "Smart text chunking for TTS processing. Splits text at natural boundaries for smoother speech.",
+      },
+    ],
   },
   {
     name: "Computer Vision",
@@ -247,10 +288,11 @@ const demoCategories: DemoCategory[] = [
         href: "/face-api",
         icon: "😊",
         title: "Face API",
-        description: "Real-time face detection and recognition. Track facial features and expressions in the browser."
-      }
-    ]
-  }
+        description:
+          "Real-time face detection and recognition. Track facial features and expressions in the browser.",
+      },
+    ],
+  },
 ];
 
 function DemoCard({ demo }: { demo: Demo }) {
@@ -286,8 +328,8 @@ export default function Home() {
             Vibe City Demos
           </h1>
           <p className="text-xl text-gray-400 max-w-2xl mx-auto">
-            Explore interactive demos showcasing 3D graphics, physics, AI, and more.
-            Built with cutting-edge web technologies.
+            Explore interactive demos showcasing 3D graphics, physics, AI, and
+            more. Built with cutting-edge web technologies.
           </p>
         </header>
 

--- a/src/app/volumetric-dust/page.tsx
+++ b/src/app/volumetric-dust/page.tsx
@@ -1,18 +1,18 @@
-'use client';
+"use client";
 
-import { useEffect, useRef } from 'react';
-import * as THREE from 'three';
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
-import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer.js";
+import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 
-import { VolumeTileSim } from '@/lib/three/volumetric-dust/VolumeTileSim';
-import { VolumetricCompositePass } from '@/lib/three/volumetric-dust/VolumetricCompositePass';
+import { VolumeTileSim } from "@/lib/three/volumetric-dust/VolumeTileSim";
+import { VolumetricCompositePass } from "@/lib/three/volumetric-dust/VolumetricCompositePass";
 
 const FULL_HEIGHT_STYLE: React.CSSProperties = {
-  width: '100%',
-  height: '100vh',
-  position: 'relative',
+  width: "100%",
+  height: "100vh",
+  position: "relative",
 };
 
 export default function VolumetricDustPage() {
@@ -30,7 +30,7 @@ export default function VolumetricDustPage() {
 
     if (!renderer.capabilities.isWebGL2) {
       // eslint-disable-next-line no-console
-      console.warn('Volumetric dust demo requires WebGL2.');
+      console.warn("Volumetric dust demo requires WebGL2.");
     }
 
     const scene = new THREE.Scene();
@@ -71,14 +71,21 @@ export default function VolumetricDustPage() {
       metalness: 0,
       roughness: 1,
     });
-    const floor = new THREE.Mesh(new THREE.PlaneGeometry(roomSize.x, roomSize.z), floorMat);
+    const floor = new THREE.Mesh(
+      new THREE.PlaneGeometry(roomSize.x, roomSize.z),
+      floorMat,
+    );
     floor.rotation.x = -Math.PI / 2;
     scene.add(floor);
 
     const brickSize = new THREE.Vector3(0.19, 0.09, 0.057);
     const brick = new THREE.Mesh(
       new THREE.BoxGeometry(brickSize.x, brickSize.y, brickSize.z),
-      new THREE.MeshStandardMaterial({ color: 0x6d3a27, metalness: 0, roughness: 0.9 }),
+      new THREE.MeshStandardMaterial({
+        color: 0x6d3a27,
+        metalness: 0,
+        roughness: 0.9,
+      }),
     );
     brick.position.set(0, 1.2, 0);
     scene.add(brick);
@@ -86,7 +93,11 @@ export default function VolumetricDustPage() {
     const GRID = 64;
     const tileSize = 3;
     const tileMin = new THREE.Vector3(-tileSize * 0.5, 0.4, -tileSize * 0.5);
-    const tileMax = new THREE.Vector3(tileSize * 0.5, 0.4 + tileSize, tileSize * 0.5);
+    const tileMax = new THREE.Vector3(
+      tileSize * 0.5,
+      0.4 + tileSize,
+      tileSize * 0.5,
+    );
 
     const sim = new VolumeTileSim(renderer, GRID);
 
@@ -118,20 +129,24 @@ export default function VolumetricDustPage() {
           tileMax.z - tileMin.z,
         ),
       ),
-      new THREE.LineBasicMaterial({ color: 0x7fbfff, transparent: true, opacity: 0.25 }),
+      new THREE.LineBasicMaterial({
+        color: 0x7fbfff,
+        transparent: true,
+        opacity: 0.25,
+      }),
     );
     tileBox.position.copy(tileMin.clone().add(tileMax).multiplyScalar(0.5));
     scene.add(tileBox);
 
-    const overlay = document.createElement('div');
-    overlay.style.position = 'absolute';
-    overlay.style.left = '12px';
-    overlay.style.top = '12px';
-    overlay.style.color = '#eaecef';
-    overlay.style.font = '600 12px system-ui, sans-serif';
-    overlay.style.background = 'rgba(0,0,0,0.4)';
-    overlay.style.padding = '10px 12px';
-    overlay.style.borderRadius = '8px';
+    const overlay = document.createElement("div");
+    overlay.style.position = "absolute";
+    overlay.style.left = "12px";
+    overlay.style.top = "12px";
+    overlay.style.color = "#eaecef";
+    overlay.style.font = "600 12px system-ui, sans-serif";
+    overlay.style.background = "rgba(0,0,0,0.4)";
+    overlay.style.padding = "10px 12px";
+    overlay.style.borderRadius = "8px";
     overlay.innerHTML = `
       <div><b>Volumetric dust (GPU) — demo</b></div>
       <div>Left-drag orbit, wheel zoom</div>
@@ -139,7 +154,7 @@ export default function VolumetricDustPage() {
     `;
     container.appendChild(overlay);
 
-    const destroyBtn = overlay.querySelector<HTMLButtonElement>('#destroyBtn');
+    const destroyBtn = overlay.querySelector<HTMLButtonElement>("#destroyBtn");
 
     const brickDensitySolid = 2000;
     const airborneFrac = 0.03;
@@ -161,13 +176,25 @@ export default function VolumetricDustPage() {
       injectTimer = burstSeconds;
 
       emitterCenterLocal.set(
-        THREE.MathUtils.clamp((brick.position.x - tileMin.x) / (tileMax.x - tileMin.x), 0.01, 0.99),
-        THREE.MathUtils.clamp((brick.position.y - tileMin.y) / (tileMax.y - tileMin.y), 0.01, 0.99),
-        THREE.MathUtils.clamp((brick.position.z - tileMin.z) / (tileMax.z - tileMin.z), 0.01, 0.99),
+        THREE.MathUtils.clamp(
+          (brick.position.x - tileMin.x) / (tileMax.x - tileMin.x),
+          0.01,
+          0.99,
+        ),
+        THREE.MathUtils.clamp(
+          (brick.position.y - tileMin.y) / (tileMax.y - tileMin.y),
+          0.01,
+          0.99,
+        ),
+        THREE.MathUtils.clamp(
+          (brick.position.z - tileMin.z) / (tileMax.z - tileMin.z),
+          0.01,
+          0.99,
+        ),
       );
     };
 
-    destroyBtn?.addEventListener('click', destroyBrick);
+    destroyBtn?.addEventListener("click", destroyBrick);
 
     const onResize = () => {
       const w = container.clientWidth;
@@ -177,7 +204,7 @@ export default function VolumetricDustPage() {
       camera.updateProjectionMatrix();
       composer.setSize(w, h);
     };
-    window.addEventListener('resize', onResize);
+    window.addEventListener("resize", onResize);
     onResize();
 
     const clock = new THREE.Clock();
@@ -230,8 +257,8 @@ export default function VolumetricDustPage() {
 
     return () => {
       cancelAnimationFrame(frameId);
-      window.removeEventListener('resize', onResize);
-      destroyBtn?.removeEventListener('click', destroyBrick);
+      window.removeEventListener("resize", onResize);
+      destroyBtn?.removeEventListener("click", destroyBrick);
       controls.dispose();
       composer.dispose();
       sim.dispose();

--- a/src/app/volumetric-dust/page.tsx
+++ b/src/app/volumetric-dust/page.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+
+import { VolumeTileSim } from '@/lib/three/volumetric-dust/VolumeTileSim';
+import { VolumetricCompositePass } from '@/lib/three/volumetric-dust/VolumetricCompositePass';
+
+const FULL_HEIGHT_STYLE: React.CSSProperties = {
+  width: '100%',
+  height: '100vh',
+  position: 'relative',
+};
+
+export default function VolumetricDustPage() {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(Math.min(2, window.devicePixelRatio));
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    container.appendChild(renderer.domElement);
+
+    if (!renderer.capabilities.isWebGL2) {
+      // eslint-disable-next-line no-console
+      console.warn('Volumetric dust demo requires WebGL2.');
+    }
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x111218);
+
+    const camera = new THREE.PerspectiveCamera(
+      60,
+      container.clientWidth / container.clientHeight,
+      0.1,
+      200,
+    );
+    camera.position.set(6, 4, 8);
+    camera.lookAt(0, 1.4, 0);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+
+    const key = new THREE.DirectionalLight(0xffffff, 3);
+    key.position.set(6, 10, 4);
+    scene.add(key);
+    scene.add(new THREE.AmbientLight(0xffffff, 0.2));
+
+    const roomSize = new THREE.Vector3(8, 4, 8);
+    const room = new THREE.Mesh(
+      new THREE.BoxGeometry(roomSize.x, roomSize.y, roomSize.z),
+      new THREE.MeshStandardMaterial({
+        color: 0x383c40,
+        metalness: 0,
+        roughness: 0.9,
+        side: THREE.BackSide,
+      }),
+    );
+    room.position.y = roomSize.y * 0.5;
+    scene.add(room);
+
+    const floorMat = new THREE.MeshStandardMaterial({
+      color: 0x2a2c30,
+      metalness: 0,
+      roughness: 1,
+    });
+    const floor = new THREE.Mesh(new THREE.PlaneGeometry(roomSize.x, roomSize.z), floorMat);
+    floor.rotation.x = -Math.PI / 2;
+    scene.add(floor);
+
+    const brickSize = new THREE.Vector3(0.19, 0.09, 0.057);
+    const brick = new THREE.Mesh(
+      new THREE.BoxGeometry(brickSize.x, brickSize.y, brickSize.z),
+      new THREE.MeshStandardMaterial({ color: 0x6d3a27, metalness: 0, roughness: 0.9 }),
+    );
+    brick.position.set(0, 1.2, 0);
+    scene.add(brick);
+
+    const GRID = 64;
+    const tileSize = 3;
+    const tileMin = new THREE.Vector3(-tileSize * 0.5, 0.4, -tileSize * 0.5);
+    const tileMax = new THREE.Vector3(tileSize * 0.5, 0.4 + tileSize, tileSize * 0.5);
+
+    const sim = new VolumeTileSim(renderer, GRID);
+
+    const renderTarget = new THREE.WebGLRenderTarget(1, 1, {
+      depthBuffer: true,
+      depthTexture: new THREE.DepthTexture(1, 1, THREE.UnsignedShortType),
+    });
+    const composer = new EffectComposer(renderer, renderTarget);
+    const renderPass = new RenderPass(scene, camera);
+    composer.addPass(renderPass);
+
+    const volumetricPass = new VolumetricCompositePass({
+      densityAtlas: sim.getDensityTexture(),
+      grid: GRID,
+      tileMin,
+      tileMax,
+      kappa_m2_per_kg: 1,
+      albedo: new THREE.Color(0.8, 0.75, 0.7),
+      stepWorld: 0.05,
+      maxSteps: 96,
+    });
+    composer.addPass(volumetricPass.pass);
+
+    const tileBox = new THREE.LineSegments(
+      new THREE.EdgesGeometry(
+        new THREE.BoxGeometry(
+          tileMax.x - tileMin.x,
+          tileMax.y - tileMin.y,
+          tileMax.z - tileMin.z,
+        ),
+      ),
+      new THREE.LineBasicMaterial({ color: 0x7fbfff, transparent: true, opacity: 0.25 }),
+    );
+    tileBox.position.copy(tileMin.clone().add(tileMax).multiplyScalar(0.5));
+    scene.add(tileBox);
+
+    const overlay = document.createElement('div');
+    overlay.style.position = 'absolute';
+    overlay.style.left = '12px';
+    overlay.style.top = '12px';
+    overlay.style.color = '#eaecef';
+    overlay.style.font = '600 12px system-ui, sans-serif';
+    overlay.style.background = 'rgba(0,0,0,0.4)';
+    overlay.style.padding = '10px 12px';
+    overlay.style.borderRadius = '8px';
+    overlay.innerHTML = `
+      <div><b>Volumetric dust (GPU) — demo</b></div>
+      <div>Left-drag orbit, wheel zoom</div>
+      <div>Click <button id="destroyBtn">Destroy brick</button> to spawn dust</div>
+    `;
+    container.appendChild(overlay);
+
+    const destroyBtn = overlay.querySelector<HTMLButtonElement>('#destroyBtn');
+
+    const brickDensitySolid = 2000;
+    const airborneFrac = 0.03;
+    const burstSeconds = 0.5;
+
+    let injectTimer = 0;
+    const emitterCenterLocal = new THREE.Vector3();
+    let emitterMassRateKgPerSec = 0;
+
+    const destroyBrick = () => {
+      if (!brick.parent) return;
+      scene.remove(brick);
+
+      const volume = brickSize.x * brickSize.y * brickSize.z;
+      const mass = brickDensitySolid * volume;
+      const dustMass = mass * airborneFrac;
+
+      emitterMassRateKgPerSec = dustMass / burstSeconds;
+      injectTimer = burstSeconds;
+
+      emitterCenterLocal.set(
+        THREE.MathUtils.clamp((brick.position.x - tileMin.x) / (tileMax.x - tileMin.x), 0.01, 0.99),
+        THREE.MathUtils.clamp((brick.position.y - tileMin.y) / (tileMax.y - tileMin.y), 0.01, 0.99),
+        THREE.MathUtils.clamp((brick.position.z - tileMin.z) / (tileMax.z - tileMin.z), 0.01, 0.99),
+      );
+    };
+
+    destroyBtn?.addEventListener('click', destroyBrick);
+
+    const onResize = () => {
+      const w = container.clientWidth;
+      const h = container.clientHeight;
+      renderer.setSize(w, h);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+      composer.setSize(w, h);
+    };
+    window.addEventListener('resize', onResize);
+    onResize();
+
+    const clock = new THREE.Clock();
+    let frameId = 0;
+
+    const animate = () => {
+      const dt = Math.min(0.033, clock.getDelta());
+      controls.update();
+
+      let emit = false;
+      const emitRadiusM = 0.35;
+
+      if (injectTimer > 0) {
+        emit = true;
+        injectTimer -= dt;
+        if (injectTimer <= 0) {
+          injectTimer = 0;
+          emitterMassRateKgPerSec = 0;
+        }
+      }
+
+      sim.update(dt, {
+        tileMin,
+        tileMax,
+        emit,
+        emitterCenterLocal,
+        emitterRadiusMeters: emitRadiusM,
+        emitterMassRateKgPerSec,
+        buoyancy: 0.25,
+        densityDissipation: 0.985,
+        velocityDamping: 0.997,
+      });
+
+      volumetricPass.setUniforms({
+        densityAtlas: sim.getDensityTexture(),
+        tileMin,
+        tileMax,
+        projectionMatrix: camera.projectionMatrix,
+        invProjectionMatrix: camera.projectionMatrixInverse,
+        viewMatrix: camera.matrixWorldInverse,
+        invViewMatrix: camera.matrixWorld,
+        voxelWorldSize: (tileMax.x - tileMin.x) / GRID,
+      });
+
+      composer.render();
+      frameId = requestAnimationFrame(animate);
+    };
+
+    frameId = requestAnimationFrame(animate);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      window.removeEventListener('resize', onResize);
+      destroyBtn?.removeEventListener('click', destroyBrick);
+      controls.dispose();
+      composer.dispose();
+      sim.dispose();
+      renderer.dispose();
+      if (renderer.domElement.parentElement === container) {
+        container.removeChild(renderer.domElement);
+      }
+      if (overlay.parentElement === container) {
+        container.removeChild(overlay);
+      }
+    };
+  }, []);
+
+  return <div ref={containerRef} style={FULL_HEIGHT_STYLE} />;
+}

--- a/src/lib/three/volumetric-dust/VolumeTileSim.ts
+++ b/src/lib/three/volumetric-dust/VolumeTileSim.ts
@@ -143,6 +143,9 @@ export class VolumeTileSim {
     densUniforms.uEmitterRadiusMeters.value = opts.emitterRadiusMeters;
     densUniforms.uEmitterMassRateKgPerSec.value = opts.emitterMassRateKgPerSec;
 
+    densUniforms.tVelocity.value = this.getVelocityTexture();
+    velUniforms.tVelocity.value = this.getVelocityTexture();
+
     this.gpu.compute();
   }
 

--- a/src/lib/three/volumetric-dust/VolumeTileSim.ts
+++ b/src/lib/three/volumetric-dust/VolumeTileSim.ts
@@ -1,0 +1,150 @@
+import * as THREE from 'three';
+import {
+  GPUComputationRenderer,
+  Variable,
+} from 'three/examples/jsm/misc/GPUComputationRenderer.js';
+
+import { advectDensityShader } from './shaders/advectDensity';
+import { advectVelocityShader } from './shaders/advectVelocity';
+
+export type SimUpdateOptions = {
+  tileMin: THREE.Vector3;
+  tileMax: THREE.Vector3;
+  emit: boolean;
+  emitterCenterLocal: THREE.Vector3;
+  emitterRadiusMeters: number;
+  emitterMassRateKgPerSec: number;
+  buoyancy: number;
+  densityDissipation: number;
+  velocityDamping: number;
+};
+
+const createTexture = (gpu: GPUComputationRenderer) => gpu.createTexture();
+
+export class VolumeTileSim {
+  private readonly grid: number;
+  private readonly tilesX: number;
+  private readonly tilesY: number;
+  private readonly atlasW: number;
+  private readonly atlasH: number;
+
+  private readonly gpu: GPUComputationRenderer;
+  private readonly densVar: Variable;
+  private readonly velVar: Variable;
+
+  constructor(renderer: THREE.WebGLRenderer, grid = 64) {
+    this.grid = grid;
+
+    this.tilesX = Math.ceil(Math.sqrt(grid));
+    this.tilesY = Math.ceil(grid / this.tilesX);
+    this.atlasW = this.tilesX * this.grid;
+    this.atlasH = this.tilesY * this.grid;
+
+    this.gpu = new GPUComputationRenderer(this.atlasW, this.atlasH, renderer);
+
+    const densTex = createTexture(this.gpu);
+    const velTex = createTexture(this.gpu);
+
+    const densArr = densTex.image.data;
+    const velArr = velTex.image.data;
+
+    for (let i = 0; i < densArr.length; i += 4) {
+      densArr[i] = 0;
+      densArr[i + 1] = 0;
+      densArr[i + 2] = 0;
+      densArr[i + 3] = 0;
+    }
+
+    for (let i = 0; i < velArr.length; i += 4) {
+      velArr[i] = 0;
+      velArr[i + 1] = 0;
+      velArr[i + 2] = 0;
+      velArr[i + 3] = 0;
+    }
+
+    this.densVar = this.gpu.addVariable('tDensity', advectDensityShader, densTex);
+    this.velVar = this.gpu.addVariable('tVelocity', advectVelocityShader, velTex);
+
+    this.gpu.setVariableDependencies(this.densVar, [this.densVar, this.velVar]);
+    this.gpu.setVariableDependencies(this.velVar, [this.velVar]);
+
+    const baseUniforms = {
+      uGrid: { value: this.grid },
+      uTilesX: { value: this.tilesX },
+      uTilesY: { value: this.tilesY },
+      uAtlasSize: { value: new THREE.Vector2(this.atlasW, this.atlasH) },
+      uDt: { value: 0.016 },
+      uTileMin: { value: new THREE.Vector3() },
+      uTileMax: { value: new THREE.Vector3() },
+    } satisfies Record<string, THREE.IUniform>;
+
+    (this.densVar.material.uniforms as Record<string, THREE.IUniform>) = {
+      ...baseUniforms,
+      tVelocity: { value: null },
+      uDissipation: { value: 0.985 },
+      uEmit: { value: 0 },
+      uEmitterCenterLocal: { value: new THREE.Vector3(0.5, 0.5, 0.5) },
+      uEmitterRadiusMeters: { value: 0.35 },
+      uEmitterMassRateKgPerSec: { value: 0 },
+      uVoxelWorldSize: { value: 0.05 },
+    };
+
+    (this.velVar.material.uniforms as Record<string, THREE.IUniform>) = {
+      ...baseUniforms,
+      uDamping: { value: 0.997 },
+      uBuoyancy: { value: 0.25 },
+      tVelocity: { value: null },
+    };
+
+    const initErr = this.gpu.init();
+    if (initErr) {
+      // eslint-disable-next-line no-console
+      console.error(initErr);
+    }
+  }
+
+  update(dt: number, opts: SimUpdateOptions) {
+    const densUniforms = this.densVar.material
+      .uniforms as Record<string, THREE.IUniform>;
+    const velUniforms = this.velVar.material
+      .uniforms as Record<string, THREE.IUniform>;
+
+    densUniforms.uDt.value = dt;
+    velUniforms.uDt.value = dt;
+
+    (densUniforms.uTileMin.value as THREE.Vector3).copy(opts.tileMin);
+    (densUniforms.uTileMax.value as THREE.Vector3).copy(opts.tileMax);
+    (velUniforms.uTileMin.value as THREE.Vector3).copy(opts.tileMin);
+    (velUniforms.uTileMax.value as THREE.Vector3).copy(opts.tileMax);
+
+    const voxelWorldSize = (opts.tileMax.x - opts.tileMin.x) / this.grid;
+    densUniforms.uVoxelWorldSize.value = voxelWorldSize;
+
+    densUniforms.uDissipation.value = opts.densityDissipation;
+    velUniforms.uDamping.value = opts.velocityDamping;
+    velUniforms.uBuoyancy.value = opts.buoyancy;
+
+    densUniforms.uEmit.value = opts.emit ? 1 : 0;
+    (densUniforms.uEmitterCenterLocal.value as THREE.Vector3).copy(
+      opts.emitterCenterLocal,
+    );
+    densUniforms.uEmitterRadiusMeters.value = opts.emitterRadiusMeters;
+    densUniforms.uEmitterMassRateKgPerSec.value = opts.emitterMassRateKgPerSec;
+
+    densUniforms.tVelocity.value = this.getVelocityTexture();
+
+    this.gpu.compute();
+  }
+
+  getDensityTexture() {
+    return this.gpu.getCurrentRenderTarget(this.densVar).texture;
+  }
+
+  getVelocityTexture() {
+    return this.gpu.getCurrentRenderTarget(this.velVar).texture;
+  }
+
+  dispose() {
+    // GPUComputationRenderer cleans up with WebGLRenderer dispose.
+  }
+}

--- a/src/lib/three/volumetric-dust/VolumeTileSim.ts
+++ b/src/lib/three/volumetric-dust/VolumeTileSim.ts
@@ -1,11 +1,11 @@
-import * as THREE from 'three';
+import * as THREE from "three";
 import {
   GPUComputationRenderer,
-  Variable,
-} from 'three/examples/jsm/misc/GPUComputationRenderer.js';
+  type Variable,
+} from "three/examples/jsm/misc/GPUComputationRenderer.js";
 
-import { advectDensityShader } from './shaders/advectDensity';
-import { advectVelocityShader } from './shaders/advectVelocity';
+import { advectDensityShader } from "./shaders/advectDensity";
+import { advectVelocityShader } from "./shaders/advectVelocity";
 
 export type SimUpdateOptions = {
   tileMin: THREE.Vector3;
@@ -62,8 +62,16 @@ export class VolumeTileSim {
       velArr[i + 3] = 0;
     }
 
-    this.densVar = this.gpu.addVariable('tDensity', advectDensityShader, densTex);
-    this.velVar = this.gpu.addVariable('tVelocity', advectVelocityShader, velTex);
+    this.densVar = this.gpu.addVariable(
+      "tDensity",
+      advectDensityShader,
+      densTex,
+    );
+    this.velVar = this.gpu.addVariable(
+      "tVelocity",
+      advectVelocityShader,
+      velTex,
+    );
 
     this.gpu.setVariableDependencies(this.densVar, [this.densVar, this.velVar]);
     this.gpu.setVariableDependencies(this.velVar, [this.velVar]);
@@ -104,10 +112,14 @@ export class VolumeTileSim {
   }
 
   update(dt: number, opts: SimUpdateOptions) {
-    const densUniforms = this.densVar.material
-      .uniforms as Record<string, THREE.IUniform>;
-    const velUniforms = this.velVar.material
-      .uniforms as Record<string, THREE.IUniform>;
+    const densUniforms = this.densVar.material.uniforms as Record<
+      string,
+      THREE.IUniform
+    >;
+    const velUniforms = this.velVar.material.uniforms as Record<
+      string,
+      THREE.IUniform
+    >;
 
     densUniforms.uDt.value = dt;
     velUniforms.uDt.value = dt;
@@ -130,8 +142,6 @@ export class VolumeTileSim {
     );
     densUniforms.uEmitterRadiusMeters.value = opts.emitterRadiusMeters;
     densUniforms.uEmitterMassRateKgPerSec.value = opts.emitterMassRateKgPerSec;
-
-    densUniforms.tVelocity.value = this.getVelocityTexture();
 
     this.gpu.compute();
   }

--- a/src/lib/three/volumetric-dust/VolumetricCompositePass.ts
+++ b/src/lib/three/volumetric-dust/VolumetricCompositePass.ts
@@ -23,7 +23,7 @@ export class VolumetricCompositePass {
     const uniforms: Record<string, THREE.IUniform> = {
       tScene: { value: null },
       tDepth: { value: null },
-      tDensity: { value: opts.densityAtlas },
+      tDensity: { value: null },
       uGrid: { value: opts.grid },
       uTilesX: { value: tilesX },
       uTilesY: { value: tilesY },
@@ -57,6 +57,9 @@ export class VolumetricCompositePass {
       fragmentShader: volumetricCompositeShader,
     });
     (this.pass as unknown as { needsSwap: boolean }).needsSwap = true;
+
+    (this.pass.uniforms as Record<string, THREE.IUniform>).tDensity.value =
+      opts.densityAtlas;
   }
 
   setUniforms(u: {

--- a/src/lib/three/volumetric-dust/VolumetricCompositePass.ts
+++ b/src/lib/three/volumetric-dust/VolumetricCompositePass.ts
@@ -1,7 +1,7 @@
-import * as THREE from 'three';
-import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+import * as THREE from "three";
+import { ShaderPass } from "three/examples/jsm/postprocessing/ShaderPass.js";
 
-import { volumetricCompositeShader } from './shaders/volumetricComposite';
+import { volumetricCompositeShader } from "./shaders/volumetricComposite";
 
 export type VolumetricPassOptions = {
   densityAtlas: THREE.Texture;
@@ -27,7 +27,9 @@ export class VolumetricCompositePass {
       uGrid: { value: opts.grid },
       uTilesX: { value: tilesX },
       uTilesY: { value: tilesY },
-      uAtlasSize: { value: new THREE.Vector2(tilesX * opts.grid, tilesY * opts.grid) },
+      uAtlasSize: {
+        value: new THREE.Vector2(tilesX * opts.grid, tilesY * opts.grid),
+      },
       uTileMin: { value: opts.tileMin.clone() },
       uTileMax: { value: opts.tileMax.clone() },
       uVoxelWorldSize: {
@@ -37,10 +39,10 @@ export class VolumetricCompositePass {
       uAlbedo: { value: opts.albedo.clone() },
       uStepWorld: { value: opts.stepWorld },
       uMaxSteps: { value: opts.maxSteps },
-      projectionMatrix: { value: new THREE.Matrix4() },
-      viewMatrix: { value: new THREE.Matrix4() },
-      invProjectionMatrix: { value: new THREE.Matrix4() },
-      invViewMatrix: { value: new THREE.Matrix4() },
+      uProjectionMatrix: { value: new THREE.Matrix4() },
+      uViewMatrix: { value: new THREE.Matrix4() },
+      uInvProjectionMatrix: { value: new THREE.Matrix4() },
+      uInvViewMatrix: { value: new THREE.Matrix4() },
     };
 
     this.pass = new ShaderPass({
@@ -72,15 +74,17 @@ export class VolumetricCompositePass {
     if (u.tileMin) (uniforms.uTileMin.value as THREE.Vector3).copy(u.tileMin);
     if (u.tileMax) (uniforms.uTileMax.value as THREE.Vector3).copy(u.tileMax);
     if (u.projectionMatrix)
-      (uniforms.projectionMatrix.value as THREE.Matrix4).copy(u.projectionMatrix);
+      (uniforms.uProjectionMatrix.value as THREE.Matrix4).copy(
+        u.projectionMatrix,
+      );
     if (u.invProjectionMatrix)
-      (uniforms.invProjectionMatrix.value as THREE.Matrix4).copy(
+      (uniforms.uInvProjectionMatrix.value as THREE.Matrix4).copy(
         u.invProjectionMatrix,
       );
     if (u.viewMatrix)
-      (uniforms.viewMatrix.value as THREE.Matrix4).copy(u.viewMatrix);
+      (uniforms.uViewMatrix.value as THREE.Matrix4).copy(u.viewMatrix);
     if (u.invViewMatrix)
-      (uniforms.invViewMatrix.value as THREE.Matrix4).copy(u.invViewMatrix);
+      (uniforms.uInvViewMatrix.value as THREE.Matrix4).copy(u.invViewMatrix);
     if (u.voxelWorldSize !== undefined)
       uniforms.uVoxelWorldSize.value = u.voxelWorldSize;
   }

--- a/src/lib/three/volumetric-dust/VolumetricCompositePass.ts
+++ b/src/lib/three/volumetric-dust/VolumetricCompositePass.ts
@@ -1,0 +1,87 @@
+import * as THREE from 'three';
+import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+
+import { volumetricCompositeShader } from './shaders/volumetricComposite';
+
+export type VolumetricPassOptions = {
+  densityAtlas: THREE.Texture;
+  grid: number;
+  tileMin: THREE.Vector3;
+  tileMax: THREE.Vector3;
+  kappa_m2_per_kg: number;
+  albedo: THREE.Color;
+  stepWorld: number;
+  maxSteps: number;
+};
+
+export class VolumetricCompositePass {
+  readonly pass: ShaderPass;
+
+  constructor(opts: VolumetricPassOptions) {
+    const tilesX = Math.ceil(Math.sqrt(opts.grid));
+    const tilesY = Math.ceil(opts.grid / tilesX);
+    const uniforms: Record<string, THREE.IUniform> = {
+      tScene: { value: null },
+      tDepth: { value: null },
+      tDensity: { value: opts.densityAtlas },
+      uGrid: { value: opts.grid },
+      uTilesX: { value: tilesX },
+      uTilesY: { value: tilesY },
+      uAtlasSize: { value: new THREE.Vector2(tilesX * opts.grid, tilesY * opts.grid) },
+      uTileMin: { value: opts.tileMin.clone() },
+      uTileMax: { value: opts.tileMax.clone() },
+      uVoxelWorldSize: {
+        value: (opts.tileMax.x - opts.tileMin.x) / opts.grid,
+      },
+      uKappa: { value: opts.kappa_m2_per_kg },
+      uAlbedo: { value: opts.albedo.clone() },
+      uStepWorld: { value: opts.stepWorld },
+      uMaxSteps: { value: opts.maxSteps },
+      projectionMatrix: { value: new THREE.Matrix4() },
+      viewMatrix: { value: new THREE.Matrix4() },
+      invProjectionMatrix: { value: new THREE.Matrix4() },
+      invViewMatrix: { value: new THREE.Matrix4() },
+    };
+
+    this.pass = new ShaderPass({
+      uniforms,
+      vertexShader: /* glsl */ `
+        varying vec2 vUv;
+        void main() {
+          vUv = uv;
+          gl_Position = vec4(position.xy, 0.0, 1.0);
+        }
+      `,
+      fragmentShader: volumetricCompositeShader,
+    });
+    (this.pass as unknown as { needsSwap: boolean }).needsSwap = true;
+  }
+
+  setUniforms(u: {
+    densityAtlas?: THREE.Texture;
+    tileMin?: THREE.Vector3;
+    tileMax?: THREE.Vector3;
+    projectionMatrix?: THREE.Matrix4;
+    invProjectionMatrix?: THREE.Matrix4;
+    viewMatrix?: THREE.Matrix4;
+    invViewMatrix?: THREE.Matrix4;
+    voxelWorldSize?: number;
+  }) {
+    const uniforms = this.pass.uniforms as Record<string, THREE.IUniform>;
+    if (u.densityAtlas) uniforms.tDensity.value = u.densityAtlas;
+    if (u.tileMin) (uniforms.uTileMin.value as THREE.Vector3).copy(u.tileMin);
+    if (u.tileMax) (uniforms.uTileMax.value as THREE.Vector3).copy(u.tileMax);
+    if (u.projectionMatrix)
+      (uniforms.projectionMatrix.value as THREE.Matrix4).copy(u.projectionMatrix);
+    if (u.invProjectionMatrix)
+      (uniforms.invProjectionMatrix.value as THREE.Matrix4).copy(
+        u.invProjectionMatrix,
+      );
+    if (u.viewMatrix)
+      (uniforms.viewMatrix.value as THREE.Matrix4).copy(u.viewMatrix);
+    if (u.invViewMatrix)
+      (uniforms.invViewMatrix.value as THREE.Matrix4).copy(u.invViewMatrix);
+    if (u.voxelWorldSize !== undefined)
+      uniforms.uVoxelWorldSize.value = u.voxelWorldSize;
+  }
+}

--- a/src/lib/three/volumetric-dust/shaders/advectDensity.ts
+++ b/src/lib/three/volumetric-dust/shaders/advectDensity.ts
@@ -1,0 +1,50 @@
+import { atlasHelpers } from './atlas';
+
+export const advectDensityShader = /* glsl */ `
+precision highp float;
+
+uniform float uGrid;
+uniform float uTilesX;
+uniform float uTilesY;
+uniform vec2  uAtlasSize;
+
+uniform float uDt;
+uniform float uDissipation;
+uniform vec3  uTileMin;
+uniform vec3  uTileMax;
+uniform float uVoxelWorldSize;
+
+uniform int   uEmit;
+uniform vec3  uEmitterCenterLocal;
+uniform float uEmitterRadiusMeters;
+uniform float uEmitterMassRateKgPerSec;
+
+uniform sampler2D tDensity;
+uniform sampler2D tVelocity;
+
+${atlasHelpers}
+
+void main() {
+  vec3 ijk, uvw;
+  fragcoord_to_ijk(gl_FragCoord.xy, uGrid, uTilesX, ijk, uvw);
+
+  vec3 vel = sample3DAtlas(tVelocity, uvw, uGrid, uTilesX, uTilesY, uAtlasSize).xyz;
+  vec3 prev = clamp(uvw - uDt * vel / vec3(uGrid), 0.0, 1.0);
+
+  float dens = sample3DAtlas(tDensity, prev, uGrid, uTilesX, uTilesY, uAtlasSize).r;
+
+  dens *= uDissipation;
+
+  if (uEmit == 1) {
+    vec3 dLocal = (uvw - uEmitterCenterLocal) * (uGrid * uVoxelWorldSize);
+    float r = length(dLocal);
+    float sigma = max(0.25 * uEmitterRadiusMeters, 0.001);
+    float gaussian = exp(-0.5 * (r * r) / (sigma * sigma));
+    float norm = 0.0635 / (sigma * sigma * sigma + 1e-6);
+    float addMassPerVoxel = uEmitterMassRateKgPerSec * uDt * gaussian * norm;
+    dens += addMassPerVoxel;
+  }
+
+  gl_FragColor = vec4(dens, 0.0, 0.0, 0.0);
+}
+`;

--- a/src/lib/three/volumetric-dust/shaders/advectDensity.ts
+++ b/src/lib/three/volumetric-dust/shaders/advectDensity.ts
@@ -1,4 +1,4 @@
-import { atlasHelpers } from './atlas';
+import { atlasHelpers } from "./atlas";
 
 export const advectDensityShader = /* glsl */ `
 precision highp float;
@@ -18,9 +18,6 @@ uniform int   uEmit;
 uniform vec3  uEmitterCenterLocal;
 uniform float uEmitterRadiusMeters;
 uniform float uEmitterMassRateKgPerSec;
-
-uniform sampler2D tDensity;
-uniform sampler2D tVelocity;
 
 ${atlasHelpers}
 

--- a/src/lib/three/volumetric-dust/shaders/advectVelocity.ts
+++ b/src/lib/three/volumetric-dust/shaders/advectVelocity.ts
@@ -1,4 +1,4 @@
-import { atlasHelpers } from './atlas';
+import { atlasHelpers } from "./atlas";
 
 export const advectVelocityShader = /* glsl */ `
 precision highp float;
@@ -13,9 +13,6 @@ uniform float uBuoyancy;
 
 uniform vec3  uTileMin;
 uniform vec3  uTileMax;
-
-varying vec2 vUv;
-uniform sampler2D tVelocity;
 
 ${atlasHelpers}
 

--- a/src/lib/three/volumetric-dust/shaders/advectVelocity.ts
+++ b/src/lib/three/volumetric-dust/shaders/advectVelocity.ts
@@ -1,0 +1,38 @@
+import { atlasHelpers } from './atlas';
+
+export const advectVelocityShader = /* glsl */ `
+precision highp float;
+uniform float uGrid;
+uniform float uTilesX;
+uniform float uTilesY;
+uniform vec2  uAtlasSize;
+
+uniform float uDt;
+uniform float uDamping;
+uniform float uBuoyancy;
+
+uniform vec3  uTileMin;
+uniform vec3  uTileMax;
+
+varying vec2 vUv;
+uniform sampler2D tVelocity;
+
+${atlasHelpers}
+
+void main() {
+  vec3 ijk, uvw;
+  fragcoord_to_ijk(gl_FragCoord.xy, uGrid, uTilesX, ijk, uvw);
+
+  vec3 vel = sample3DAtlas(tVelocity, uvw, uGrid, uTilesX, uTilesY, uAtlasSize).xyz;
+
+  vec3 prev = clamp(uvw - uDt * vel / vec3(uGrid), 0.0, 1.0);
+
+  vec3 vPrev = sample3DAtlas(tVelocity, prev, uGrid, uTilesX, uTilesY, uAtlasSize).xyz;
+
+  vPrev += vec3(0.0, uBuoyancy, 0.0) * uDt;
+
+  vPrev *= uDamping;
+
+  gl_FragColor = vec4(vPrev, 0.0);
+}
+`;

--- a/src/lib/three/volumetric-dust/shaders/atlas.ts
+++ b/src/lib/three/volumetric-dust/shaders/atlas.ts
@@ -1,0 +1,64 @@
+export const atlasHelpers = /* glsl */ `
+vec2 atlasUV(float x, float y, float z, float uGrid, float uTilesX, float uTilesY, vec2 uAtlasSize) {
+  float slice = z;
+  float tx = mod(slice, uTilesX);
+  float ty = floor(slice / uTilesX);
+  float u = (x + 0.5 + tx * uGrid) / (uTilesX * uGrid);
+  float v = (y + 0.5 + ty * uGrid) / (uTilesY * uGrid);
+  return vec2(u, v);
+}
+
+vec4 fetchVoxel(sampler2D tex, vec3 ijk, float uGrid, float uTilesX, float uTilesY, vec2 uAtlasSize) {
+  vec2 uv = atlasUV(ijk.x, ijk.y, ijk.z, uGrid, uTilesX, uTilesY, uAtlasSize);
+  return texture2D(tex, uv);
+}
+
+vec4 sample3DAtlas(sampler2D tex, vec3 uvw, float uGrid, float uTilesX, float uTilesY, vec2 uAtlasSize) {
+  vec3 coord = clamp(uvw * (uGrid - 1.0), 0.0, uGrid - 1.0001);
+  vec3 base = floor(coord);
+  vec3 f = fract(coord);
+
+  vec3 c000 = base;
+  vec3 c100 = base + vec3(1.0, 0.0, 0.0);
+  vec3 c010 = base + vec3(0.0, 1.0, 0.0);
+  vec3 c110 = base + vec3(1.0, 1.0, 0.0);
+  vec3 c001 = base + vec3(0.0, 0.0, 1.0);
+  vec3 c101 = base + vec3(1.0, 0.0, 1.0);
+  vec3 c011 = base + vec3(0.0, 1.0, 1.0);
+  vec3 c111 = base + vec3(1.0, 1.0, 1.0);
+
+  vec4 s000 = fetchVoxel(tex, c000, uGrid, uTilesX, uTilesY, uAtlasSize);
+  vec4 s100 = fetchVoxel(tex, c100, uGrid, uTilesX, uTilesY, uAtlasSize);
+  vec4 s010 = fetchVoxel(tex, c010, uGrid, uTilesX, uTilesY, uAtlasSize);
+  vec4 s110 = fetchVoxel(tex, c110, uGrid, uTilesX, uTilesY, uAtlasSize);
+  vec4 s001 = fetchVoxel(tex, c001, uGrid, uTilesX, uTilesY, uAtlasSize);
+  vec4 s101 = fetchVoxel(tex, c101, uGrid, uTilesX, uTilesY, uAtlasSize);
+  vec4 s011 = fetchVoxel(tex, c011, uGrid, uTilesX, uTilesY, uAtlasSize);
+  vec4 s111 = fetchVoxel(tex, c111, uGrid, uTilesX, uTilesY, uAtlasSize);
+
+  vec4 s00 = mix(s000, s100, f.x);
+  vec4 s10 = mix(s010, s110, f.x);
+  vec4 s01 = mix(s001, s101, f.x);
+  vec4 s11 = mix(s011, s111, f.x);
+
+  vec4 s0 = mix(s00, s10, f.y);
+  vec4 s1 = mix(s01, s11, f.y);
+
+  return mix(s0, s1, f.z);
+}
+
+void fragcoord_to_ijk(vec2 fragCoord, float uGrid, float uTilesX, out vec3 ijk, out vec3 uvw) {
+  float px = fragCoord.x - 0.5;
+  float py = fragCoord.y - 0.5;
+
+  float tx = floor(px / uGrid);
+  float ty = floor(py / uGrid);
+
+  float i = px - tx * uGrid;
+  float j = py - ty * uGrid;
+  float k = tx + ty * uTilesX;
+
+  ijk = vec3(i, j, k);
+  uvw = (ijk + 0.5) / vec3(uGrid);
+}
+`;

--- a/src/lib/three/volumetric-dust/shaders/volumetricComposite.ts
+++ b/src/lib/three/volumetric-dust/shaders/volumetricComposite.ts
@@ -1,0 +1,110 @@
+import { atlasHelpers } from './atlas';
+
+export const volumetricCompositeShader = /* glsl */ `
+precision highp float;
+
+uniform sampler2D tScene;
+uniform sampler2D tDepth;
+uniform sampler2D tDensity;
+
+uniform float uGrid;
+uniform float uTilesX;
+uniform float uTilesY;
+uniform vec2  uAtlasSize;
+
+uniform vec3  uTileMin;
+uniform vec3  uTileMax;
+uniform float uVoxelWorldSize;
+uniform float uKappa;
+uniform vec3  uAlbedo;
+uniform float uStepWorld;
+uniform float uMaxSteps;
+
+uniform mat4 projectionMatrix;
+uniform mat4 viewMatrix;
+uniform mat4 invProjectionMatrix;
+uniform mat4 invViewMatrix;
+
+varying vec2 vUv;
+
+${atlasHelpers}
+
+vec2 intersectAABB(vec3 ro, vec3 rd, vec3 bmin, vec3 bmax) {
+  vec3 inv = 1.0 / rd;
+  vec3 t0 = (bmin - ro) * inv;
+  vec3 t1 = (bmax - ro) * inv;
+  vec3 tsm = min(t0, t1);
+  vec3 tbg = max(t0, t1);
+  float tEnter = max(max(tsm.x, tsm.y), tsm.z);
+  float tExit  = min(min(tbg.x, tbg.y), tbg.z);
+  return vec2(tEnter, tExit);
+}
+
+vec3 worldPosFromDepth(vec2 uv, float depth) {
+  vec4 clip = vec4(uv * 2.0 - 1.0, depth * 2.0 - 1.0, 1.0);
+  vec4 view = invProjectionMatrix * clip;
+  view /= view.w;
+  vec4 world = invViewMatrix * view;
+  return world.xyz;
+}
+
+void main() {
+  vec2 uv = vUv;
+
+  vec3 sceneCol = texture2D(tScene, uv).rgb;
+  float depth = texture2D(tDepth, uv).x;
+
+  vec3 camPos = (invViewMatrix * vec4(0.0, 0.0, 0.0, 1.0)).xyz;
+  vec3 wsAtDepth = worldPosFromDepth(uv, depth);
+  vec3 rd = normalize(wsAtDepth - camPos);
+
+  vec2 tAB = intersectAABB(camPos, rd, uTileMin, uTileMax);
+  float tEnter = max(tAB.x, 0.0);
+  float tExit = tAB.y;
+
+  if (tExit <= tEnter) {
+    gl_FragColor = vec4(sceneCol, 1.0);
+    return;
+  }
+
+  float tScene = length(wsAtDepth - camPos);
+  tExit = min(tExit, tScene);
+
+  float stepLen = uStepWorld;
+  int MAX_STEPS = int(uMaxSteps);
+  float t = tEnter;
+  vec3 accum = vec3(0.0);
+  float Tr = 1.0;
+
+  vec2 atlasSize = vec2(uTilesX * uGrid, uTilesY * uGrid);
+
+  for (int i = 0; i < 2048; ++i) {
+    if (i >= MAX_STEPS) break;
+    if (t > tExit || Tr < 0.01) break;
+
+    vec3 wp = camPos + rd * t;
+    vec3 lp = (wp - uTileMin) / (uTileMax - uTileMin);
+
+    if (any(lessThan(lp, vec3(0.0))) || any(greaterThan(lp, vec3(1.0)))) {
+      t += stepLen;
+      continue;
+    }
+
+    float densKgPerVoxel = sample3DAtlas(tDensity, lp, uGrid, uTilesX, uTilesY, atlasSize).r;
+    float conc = densKgPerVoxel / (uVoxelWorldSize * uVoxelWorldSize * uVoxelWorldSize);
+
+    float tau = uKappa * conc * stepLen;
+    float a = 1.0 - exp(-tau);
+
+    vec3 col = uAlbedo * a;
+
+    accum += Tr * col;
+    Tr *= (1.0 - a);
+
+    t += stepLen;
+  }
+
+  vec3 outCol = sceneCol * Tr + accum;
+  gl_FragColor = vec4(outCol, 1.0);
+}
+`;

--- a/src/lib/three/volumetric-dust/shaders/volumetricComposite.ts
+++ b/src/lib/three/volumetric-dust/shaders/volumetricComposite.ts
@@ -1,4 +1,4 @@
-import { atlasHelpers } from './atlas';
+import { atlasHelpers } from "./atlas";
 
 export const volumetricCompositeShader = /* glsl */ `
 precision highp float;
@@ -20,10 +20,10 @@ uniform vec3  uAlbedo;
 uniform float uStepWorld;
 uniform float uMaxSteps;
 
-uniform mat4 projectionMatrix;
-uniform mat4 viewMatrix;
-uniform mat4 invProjectionMatrix;
-uniform mat4 invViewMatrix;
+uniform mat4 uProjectionMatrix;
+uniform mat4 uViewMatrix;
+uniform mat4 uInvProjectionMatrix;
+uniform mat4 uInvViewMatrix;
 
 varying vec2 vUv;
 
@@ -42,9 +42,9 @@ vec2 intersectAABB(vec3 ro, vec3 rd, vec3 bmin, vec3 bmax) {
 
 vec3 worldPosFromDepth(vec2 uv, float depth) {
   vec4 clip = vec4(uv * 2.0 - 1.0, depth * 2.0 - 1.0, 1.0);
-  vec4 view = invProjectionMatrix * clip;
+  vec4 view = uInvProjectionMatrix * clip;
   view /= view.w;
-  vec4 world = invViewMatrix * view;
+  vec4 world = uInvViewMatrix * view;
   return world.xyz;
 }
 
@@ -54,7 +54,7 @@ void main() {
   vec3 sceneCol = texture2D(tScene, uv).rgb;
   float depth = texture2D(tDepth, uv).x;
 
-  vec3 camPos = (invViewMatrix * vec4(0.0, 0.0, 0.0, 1.0)).xyz;
+  vec3 camPos = (uInvViewMatrix * vec4(0.0, 0.0, 0.0, 1.0)).xyz;
   vec3 wsAtDepth = worldPosFromDepth(uv, depth);
   vec3 rd = normalize(wsAtDepth - camPos);
 


### PR DESCRIPTION
## Summary
- add a /volumetric-dust Next.js page that sets up the scene, GPU simulation, and composite pass
- implement reusable VolumeTileSim and VolumetricCompositePass helpers for the volumetric dust pipeline
- add GLSL shader modules for advection and volumetric compositing using a 3D density atlas

## Testing
- npm run lint -- src/app/volumetric-dust/page.tsx src/lib/three/volumetric-dust *(fails: biome executable missing because dependencies are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68fcc45958e4832f9d0d2d8b5f8ed221