### PR TITLE
Optimize navmesh sync by caching static terrain

### DIFF
--- a/src/lib/navcat-rapier/generate.detail.test.ts
+++ b/src/lib/navcat-rapier/generate.detail.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import Rapier from "@dimforge/rapier3d-compat";
 import { extractRapierToNavcat } from "./extract";
-import { generateSoloNavMeshFromGeometry } from "./generate";
+import { generateSoloNavMeshFromGeometry, type NavMeshGenerationResult } from "./generate";
 
 describe("generateSoloNavMeshFromGeometry - detail mesh behavior", () => {
   let rapier: typeof Rapier;
@@ -39,10 +39,13 @@ describe("generateSoloNavMeshFromGeometry - detail mesh behavior", () => {
     const extraction = extractRapierToNavcat(w, rapier);
     expect(extraction).not.toBeNull();
 
-    const result = generateSoloNavMeshFromGeometry(extraction!, { skipDetailMesh: true });
+    const result: NavMeshGenerationResult | null = generateSoloNavMeshFromGeometry(extraction!, {
+      skipDetailMesh: true,
+    });
     expect(result).not.toBeNull();
     expect(result!.navMesh).toBeDefined();
     expect(Object.keys(result!.navMesh.tiles).length).toBeGreaterThan(0);
+    expect(result!.stats.reusedNavMesh).toBe(false);
 
     const tile = Object.values(result!.navMesh.tiles)[0] as any;
     // Detail arrays should be empty when skipped
@@ -59,7 +62,9 @@ describe("generateSoloNavMeshFromGeometry - detail mesh behavior", () => {
     const extraction = extractRapierToNavcat(w, rapier);
     expect(extraction).not.toBeNull();
 
-    const result = generateSoloNavMeshFromGeometry(extraction!, { preset: "default" });
+    const result: NavMeshGenerationResult | null = generateSoloNavMeshFromGeometry(extraction!, {
+      preset: "default",
+    });
     expect(result).not.toBeNull();
     expect(result!.navMesh).toBeDefined();
     expect(Object.keys(result!.navMesh.tiles).length).toBeGreaterThan(0);
@@ -92,7 +97,9 @@ describe("generateSoloNavMeshFromGeometry - detail mesh behavior", () => {
     const extraction = extractRapierToNavcat(w, rapier);
     expect(extraction).not.toBeNull();
 
-    const result = generateSoloNavMeshFromGeometry(extraction!, { preset: "crisp" });
+    const result: NavMeshGenerationResult | null = generateSoloNavMeshFromGeometry(extraction!, {
+      preset: "crisp",
+    });
     expect(result).not.toBeNull();
     expect(result!.navMesh).toBeDefined();
     expect(Object.keys(result!.navMesh.tiles).length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- add dynamic obstacle metadata and static collider tracking to the Rapier extraction pipeline so moving bodies are treated as cylindrical blockers
- cache the static heightfield build inside navmesh generation and stamp dynamic obstacles onto cloned compact heightfields for incremental rebuilds
- reuse the cached builder inside the React hook and update unit tests to reflect the new obstacle-oriented extraction behaviour

## Testing
- `npx vitest run` *(fails: local env lacks compatible vitest package and install step cannot fetch required binaries)*
- `npm run typecheck` *(fails: repository dependencies such as react/@recast-navigation are not installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_69089e9e8770832fb8e20bacb6171bdb