### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Vibe City is a Next.js 15 web app with 3D interactive demos using Three.js/React Three Fiber, Rapier physics, and various AI features. It is a purely client-side application — no database, no backend API routes, no external services required to run.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` |
+| Dev server | `npm run dev` (port 3000) |
+| Lint | `npm run lint` (biome check) |
+| Format | `npm run format` |
+| Tests | `npm test` (vitest run) |
+| Storybook | `npm run storybook` (port 6006) |
+
+### Non-obvious caveats
+
+- **Node version**: `.nvmrc` specifies v22.12.0. Any Node 22.x works.
+- **Playwright browsers required for tests**: Storybook browser tests (vitest Storybook project) need Playwright Chromium installed (`npx playwright install chromium`). Without it, `npm test` will fail on the storybook test project.
+- **FluidHTN WASM tests fail without Docker build**: 14 tests in `bunker_planner.spec.ts` and `fluidhtn-demo.test.ts` expect the WASM bundle at `public/planner/_framework/dotnet.js`. This requires `npm run build:planner` (Docker needed). These failures are expected in environments without Docker.
+- **Biome lint has pre-existing formatting warnings**: `npm run lint` reports formatting issues already in the codebase (not introduced by agent changes).
+- **3D demos are heavy**: Pages using physics + 3D rendering (e.g., `/destructible-stress`) may take several seconds to initialize. Wait for the scene to load before interacting.
+- **Google Gemini API key**: AI chat features require a user-supplied API key stored in browser localStorage. No server-side env vars needed.
+- **Click-to-fire projectiles**: On the `/destructible-stress` page, clicking on the 3D canvas in "projectile" mode fires a projectile at that location. The control panel allows switching structures and interaction modes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for this codebase.

### What's included

- Key commands table (dev server, lint, tests, storybook)
- Non-obvious caveats: Playwright browser requirement for storybook tests, FluidHTN WASM test expectations, biome lint pre-existing warnings, 3D demo initialization timing, and client-side API key handling

### Environment verification

All core development workflows were verified:

| Check | Status |
|-------|--------|
| `npm install` | ✅ |
| `npm run lint` | ✅ (pre-existing formatting warnings) |
| `npm test` | ✅ 50 passed, 14 failed (expected — FluidHTN WASM tests need Docker) |
| `npm run dev` | ✅ Dev server running on port 3000 |
| Destructible stress demo | ✅ Fully interactive |

### Demo

[destructible-stress-fractured-wall-hut-demo.mp4](https://cursor.com/agents/bc-935d8cd1-4766-4dd1-bf0a-6aebe4e3efee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdestructible-stress-fractured-wall-hut-demo.mp4)

Fractured wall hut structure destroyed by projectile impacts in the `/destructible-stress` page.

[Fractured wall hut before destruction](https://cursor.com/agents/bc-935d8cd1-4766-4dd1-bf0a-6aebe4e3efee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffractured_wall_hut_before.webp)
[Fractured wall hut after destruction](https://cursor.com/agents/bc-935d8cd1-4766-4dd1-bf0a-6aebe4e3efee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffractured_wall_hut_after_destruction.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-935d8cd1-4766-4dd1-bf0a-6aebe4e3efee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-935d8cd1-4766-4dd1-bf0a-6aebe4e3efee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

